### PR TITLE
Bump version to 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,9 @@
 
 - Migrate to latest version of jetpack library [https://developer.android.com/jetpack/androidx/releases/credentials#groovy](https://developer.android.com/jetpack/androidx/releases/credentials#groovy)
 - Google Sign in with Credential Manager 
+
+# 0.0.5
+
+- Update all dependencies to latest version Thanks to [@jlafazia-figure](https://github.com/jlafazia-figure)
+- Bug fixes and improvements in example application
+- Update README.md with latest information

--- a/README.md
+++ b/README.md
@@ -54,7 +54,12 @@ buildTypes {
 - Add package ID and Get debug SHA-1 and release SHA-1
    - `cd android`
    - `./gradlew signInReport`
-- Copy `WebClient(auto created by google)`
+- Add SHA-1 to google cloud console 
+- Go to the Credentials page.
+- Click Create credentials > OAuth client ID.
+- Select the Web application type.
+- You can ignore the "Authorized JavaScript Origins" and "Authorized redirect URIs" fields for now.
+- Copy `Client ID(from web Application)`.
 
 ## Usage in flutter
 - import the package

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.smkwinner.cred_manager.credential_manager'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.22'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -24,21 +24,20 @@ allprojects {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
-
 android {
     if (project.android.hasProperty("namespace")) {
         namespace 'com.smkwinner.cred_manager.credential_manager'
     }
 
-    compileSdkVersion 34
+    compileSdk 34
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {
@@ -47,14 +46,13 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         multiDexEnabled true
-
     }
 
     dependencies {
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
-        testImplementation 'org.mockito:mockito-core:5.0.0'
+        testImplementation 'org.mockito:mockito-core:5.10.0'
     }
 
     testOptions {
@@ -62,32 +60,23 @@ android {
             useJUnitPlatform()
 
             testLogging {
-               events "passed", "skipped", "failed", "standardOut", "standardError"
-               outputs.upToDateWhen {false}
-               showStandardStreams = true
+                events "passed", "skipped", "failed", "standardOut", "standardError"
+                outputs.upToDateWhen { false }
+                showStandardStreams = true
             }
         }
     }
 }
 
 dependencies {
-
-    implementation 'androidx.annotation:annotation:1.7.1'
-
+    implementation 'androidx.annotation:annotation:1.8.0'
     //jetpack credential Manager
-    implementation "androidx.credentials:credentials:1.3.0-alpha01"
-
+    implementation "androidx.credentials:credentials:1.2.2"
     // optional - needed for credentials support from play services, for devices running
     // Android 13 and below.
-    implementation "androidx.credentials:credentials-play-services-auth:1.3.0-alpha01"
-
-
+    implementation "androidx.credentials:credentials-play-services-auth:1.2.2"
     //For google sign in
     implementation "com.google.android.libraries.identity.googleid:googleid:1.1.0"
-
     //Co-routine
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
-
-
-
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/src/main/kotlin/com/smkwinner/cred_manager/credential_manager/CredentialManagerPlugin.kt
+++ b/android/src/main/kotlin/com/smkwinner/cred_manager/credential_manager/CredentialManagerPlugin.kt
@@ -68,7 +68,7 @@ class CredentialManagerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
             utils.initialize(preferImmediatelyAvailableCredentials, googleClientId, currentContext)
 
         if (exception != null) {
-            result.error(exception.code.toString(), exception.details, exception.message)
+            result.error(exception.code.toString(), exception.message, exception.details)
         } else {
             result.success(message)
         }
@@ -84,7 +84,7 @@ class CredentialManagerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
                 utils.savePasswordCredentials(username = username, password = password, context = currentContext)
 
             if (exception != null) {
-                result.error(exception.code.toString(), exception.details, exception.message)
+                result.error(exception.code.toString(), exception.message, exception.details)
             } else {
                 result.success(message)
             }
@@ -96,7 +96,7 @@ class CredentialManagerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
             utils.getPasswordCredentials(context = currentContext)
 
         if (exception != null) {
-            result.error(exception.code.toString(), exception.details, exception.message)
+            result.error(exception.code.toString(), exception.message, exception.details)
         } else {
             val resultMap = if (credentials.first != null) {
                 mapOf("type" to "PasswordCredentials","data" to mapOf("username" to credentials.first?.username, "password" to credentials.first?.password))
@@ -121,7 +121,7 @@ class CredentialManagerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
             utils.saveGoogleCredentials(context = currentContext)
 
         if (exception != null) {
-            result.error(exception.code.toString(), exception.details, exception.message)
+            result.error(exception.code.toString(), exception.message, exception.details)
         } else {
             val credentialMap = mapOf(
                 "id" to credential?.id,

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -22,18 +22,28 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
+if (flutterMinSdkVersion == null) {
+    flutterMinSdkVersion = '24'
+}
+
+def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
+if (flutterTargetSdkVersion == null) {
+    flutterTargetSdkVersion = '34'
+}
+
 android {
     namespace "com.smkwinner.cred_manager.credential_manager_example"
-    compileSdkVersion 34
+    compileSdk 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     sourceSets {
@@ -45,15 +55,14 @@ android {
         applicationId "com.smkwinner.cred_manager.credential_manager_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        minSdkVersion flutterMinSdkVersion
+        targetSdkVersion flutterTargetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
             minifyEnabled true
@@ -67,5 +76,5 @@ flutter {
 }
 
 dependencies {
-   // implementation 'com.google.android.gms:play-services-auth:20.4.1'
+    implementation "com.android.support:multidex:1.0.3"
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,27 +1,27 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
     <application
-        android:label="credential_manager_example"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:label="credential_manager_example">
         <activity
             android:name=".MainActivity"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:exported="true"
+            android:hardwareAccelerated="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
-            android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
@@ -30,5 +30,5 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
-    
+
 </manifest>

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,17 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.7.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        //classpath 'com.google.gms:google-services:4.3.15'
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -5,16 +5,21 @@ pluginManagement {
         def flutterSdkPath = properties.getProperty("flutter.sdk")
         assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
         return flutterSdkPath
-    }
-    settings.ext.flutterSdkPath = flutterSdkPath()
+    }()
 
-    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-    plugins {
-        id "dev.flutter.flutter-gradle-plugin" version "1.0.0" apply false
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
     }
 }
 
-include ":app"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "7.4.2" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
+}
 
-apply from: "${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+include ":app"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,7 +4,6 @@ import 'dart:async';
 import 'dart:developer';
 
 import 'package:credential_manager/credential_manager.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 // Create an instance of CredentialManager for managing credentials
@@ -22,8 +21,8 @@ Future<void> main() async {
   if (credentialManager.isSupportedPlatform) {
     await credentialManager.init(
         preferImmediatelyAvailableCredentials: true,
-        //optional perameter for integrate google signing
-        googleClientId: googleClientId);
+        //optional parameter for integrate google signing
+        googleClientId: googleClientId.isEmpty?null:googleClientId,);
   }
 
   // Run the app
@@ -178,11 +177,19 @@ class _LoginScreenState extends State<LoginScreen> {
                     MaterialButton(
                       onPressed: () async {
                         try {
-                          final res =
+                          final credential =
                               await credentialManager.saveGoogleCredential();
-                          if (kDebugMode) {
-                            print(res?.toJson());
-                          }
+                          String message = credential?.toJson().toString() ?? "";
+
+                          ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text("Successfully retrieved credential")));
+                          showDialog(
+                            context: context,
+                            builder: (context) => AlertDialog(
+                              title: const Text("Login success"),
+                              content: Text(message),
+                            ),
+                          );
                         } on CredentialException catch (e) {
                           log(e.message);
                         }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.0.5"
   crypto:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.4"
   crypto:
     dependency: transitive
     description:
@@ -108,10 +108,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -153,6 +153,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -165,42 +189,42 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: ae68c7bfcd7383af3629daafb32fb4e8681c7154428da4febcff06200585f102
+      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.4"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -221,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      sha256: "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.4"
+    version: "5.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -282,10 +306,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -306,26 +330,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "11.10.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.0"
+    version: "14.2.1"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3c923e918918feeb90c4c9fdf1fe39220fa4c0e8e2c0fffaded174498ef86c49"
+      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/channel/credential_manager_method_channel.dart
+++ b/lib/src/channel/credential_manager_method_channel.dart
@@ -151,12 +151,24 @@ class MethodChannelCredentialManager extends CredentialManagerPlatform {
                 : "Login cancelled",
             details: e.details);
       case "202":
-        return CredentialException(
-            code: 202,
-            message: isGoogleCredentials
-                ? "No Google credentials found"
-                : "No credentials found",
-            details: e.details);
+        // Android returns a 202 for two separate cases:
+        // 1) [28433] Cannot find a matching credential
+        // 2) [28436] Caller has been temporarily blocked due to too many
+        // canceled sign-in prompts.
+        if (e.details?.toString().contains('[28436]') == true) {
+          return CredentialException(
+            code: 205,
+            message: "Temporarily blocked",
+            details: e.details,
+          );
+        } else {
+          return CredentialException(
+              code: 202,
+              message: isGoogleCredentials
+                  ? "No Google credentials found"
+                  : "No credentials found",
+              details: e.details);
+        }
       case "203":
         return CredentialException(
             code: 203,

--- a/lib/src/exceptions/exceptions.dart
+++ b/lib/src/exceptions/exceptions.dart
@@ -1,4 +1,29 @@
 /// Exception class representing errors related to credential operations.
+///
+/// ```dart
+///   code   message
+///    101   Initialization failure
+///    102   Plugin exception
+///    103   Not implemented
+///
+///    201   Login cancelled
+///    202   No credentials found
+///    203   Mismatched credentials
+///    204   Login failed
+///    205   Temporarily blocked (due to too many canceled sign-in prompts)
+///
+///    301   Save Credentials cancelled
+///    302   Create Credentials failed
+///
+///    401   Encryption failed
+///    402   Decryption failed
+///
+///    501   Received an invalid google id token response
+///    502   Invalid request
+///    503   Google client is not initialized yet
+///    504   Credentials operation failed
+///    505   Google credential decode error
+/// ```
 class CredentialException implements Exception {
   /// A numeric code identifying the specific error.
   final int code;
@@ -16,27 +41,3 @@ class CredentialException implements Exception {
     required this.details,
   });
 }
-
-/// Table for error codes and corresponding messages in [CredentialException].
-/*
-  code  message
-  101   Initialization failure
-  102   Plugin exception
-  103   Not implemented
-
-  201   Login cancelled
-  202   No credentials found
-  203   Mismatched credentials
-  204   Login failed
-
-  301   Save Credentials cancelled
-  302   Create Credentials failed
-
-  401   Encryption failed
-  402   Decryption failed
-
-  501  Received an invalid google id token response
-  502  Invalid request
-  503  Google client is not initialized yet
-  504  Credentials operation failed
-*/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: credential_manager
 description: Credential Manager plugin,Help one-tap Login functionality and store credentials in Google service account of user.
 
-version: 0.0.4
+version: 0.0.5
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 
 environment:


### PR DESCRIPTION
## Changes
- Updates Androidx:credentials to latest stable 1.2.2
- Fixes `exception.details` - was being set to the wrong parameter and eventually overwritten
- Adds new exception type with code `205` to handle the 'cooldown' case documented [here]()
  - You can hit this case by dismissing the 'sign-in' prompt 4 times in the same app in the same day.
  - During this locked-out time the API immediately returns `202 no credentials found` for all get password requests which is misleading.
- Updates Gradle plugin to the latest that's completely supported by Flutter (7.4.2)
- Updates kotlin to 1.9.22
- Updates Java SDK to 17
- Updates other dependencies to latest versions
- Updates to support Flutter 3.22
  - Updates min Android SDK from 19 to 21 to support latest Flutter 3.22 [breaking changes](https://docs.flutter.dev/release/breaking-changes/android-kitkat-deprecation)
  - Updates for Flutter's [Deprecated imperative apply of Flutter's Gradle plugins](https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply)
  - NOTE: Multidex apps that depend on this package may need a `minSdkVersion` of at least 24
  - Bug in login example with Empty Client Id
  - Update readme.md for getting google webClientID
  - Bump version to 0.0.5