### PR TITLE
chore: release v3.0.0 for credential_manager_ios and credential_manager

### DIFF
--- a/docSite/src/pages/ConfigurationPage.tsx
+++ b/docSite/src/pages/ConfigurationPage.tsx
@@ -111,6 +111,62 @@ Allow: /.well-known/`}
         Password autofill was introduced with iOS 11 and got major updates with iOS 12, including security code autofill, password suggestions, and support for third-party managers.
       </p>
 
+      <h3 className="mt-6 mb-2">Swift Package Manager (SPM) Support</h3>
+
+      <p className="mb-4">
+        Starting with version 3.0.0, <code>credential_manager_ios</code> ships a <code>Package.swift</code> alongside
+        its existing podspec, so it works with both <strong>Swift Package Manager</strong> and <strong>CocoaPods</strong>.
+        Flutter uses Swift Package Manager by default starting with Flutter 3.24, and CocoaPods' trunk registry goes
+        read-only on December 2, 2026 — after that date new plugin versions can only be published via SPM, so
+        migrating ahead of time is recommended.
+      </p>
+
+      <h4 className="mt-4 mb-2 font-semibold">Enabling SPM</h4>
+      <ol className="list-decimal pl-6 mb-6">
+        <li className="mb-2">
+          Enable Swift Package Manager support in Flutter, if it isn't already the default for your channel:
+          <CodeBlock code="flutter config --enable-swift-package-manager" language="bash" />
+        </li>
+        <li className="mb-2">
+          Run <code>flutter pub get</code> and then <code>flutter run</code> or <code>flutter build ios</code>.
+          Flutter automatically detects that <code>credential_manager_ios</code> ships a <code>Package.swift</code>{' '}
+          and integrates it as a Swift Package instead of a CocoaPods dependency.
+        </li>
+        <li className="mb-2">
+          If your project still has an <code>ios/Podfile</code> with other CocoaPods dependencies, Flutter keeps
+          using CocoaPods for those while resolving SPM-compatible plugins (like this one) through Swift Package
+          Manager — no manual migration of the whole project is required.
+        </li>
+      </ol>
+
+      <h4 className="mt-4 mb-2 font-semibold">Migrating an existing CocoaPods-only project</h4>
+      <ol className="list-decimal pl-6 mb-6">
+        <li className="mb-2">
+          Once every plugin your app depends on supports SPM, remove CocoaPods integration:
+          <CodeBlock
+            code={`cd ios
+pod deintegrate`}
+            language="bash"
+          />
+        </li>
+        <li className="mb-2">
+          Delete the generated <code>Podfile</code> and <code>Podfile.lock</code> if you have no remaining
+          CocoaPods-only dependencies.
+        </li>
+        <li className="mb-2">
+          Re-run <code>flutter build ios</code> — Flutter regenerates the Xcode project against Swift Package
+          Manager.
+        </li>
+      </ol>
+
+      <p className="mb-4">
+        See Flutter's official{' '}
+        <a href="https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers" target="_blank">
+          Swift Package Manager for app developers
+        </a>{' '}
+        guide for more details.
+      </p>
+
       <h3 className="mt-6 mb-2">Enabling Password AutoFill</h3>
 
       <ol className="list-decimal pl-6 mb-6">

--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-# 2.0.8
+# 3.0.0
+- Bumped `credential_manager_ios` to `^3.0.0`, which adds Swift Package Manager (SPM) support alongside the existing CocoaPods integration
+- No breaking changes to the Dart API; apps still on CocoaPods continue to work unchanged
+
+## 2.0.8
 - Added `isGmsAvailable` to platform interface
 - Handle `exception code 209` for Google Play Services not available
 - on Android, Google account is not logged in, the plugin will  launch Google Sign-In flow.

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Credential Manager plugin. Provides one-tap login functionality and stores credentials
   in the user's Google account on Android and in the Keychain on iOS.
 
-version: 2.0.8
+version: 3.0.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 
@@ -18,7 +18,7 @@ dependencies:
     sdk: flutter
   credential_manager_platform_interface: ^2.0.8
   credential_manager_android: ^2.0.8
-  credential_manager_ios: ^2.0.8
+  credential_manager_ios: ^3.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/credential_manager_ios/CHANGELOG.md
+++ b/packages/credential_manager_ios/CHANGELOG.md
@@ -1,4 +1,9 @@
-# 2.0.8
+# 3.0.0
+- Added Swift Package Manager (SPM) support via a new `Package.swift` manifest, alongside the existing CocoaPods podspec
+- Moved Swift sources from `ios/Classes` to `ios/credential_manager_ios/Sources/credential_manager_ios` (single source of truth for both CocoaPods and SPM)
+- No breaking changes to the Dart API; existing CocoaPods-based apps continue to work unchanged
+
+## 2.0.8
 - Added `isGmsAvailable` to platform interface
 - Handle `exception code 209` for Google Play Services not available
 - on Android, Google account is not logged in, the plugin will  launch Google Sign-In flow.

--- a/packages/credential_manager_ios/pubspec.yaml
+++ b/packages/credential_manager_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: credential_manager_ios
 description: iOS implementation of the credential_manager plugin using Keychain and Autofill.
-version: 2.0.8
+version: 3.0.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose$
 


### PR DESCRIPTION
## Summary
- Docs: adds a Swift Package Manager setup/migration guide to the iOS Configuration page (docSite), ahead of publishing.
- Bumps `credential_manager_ios` 2.0.8 → **3.0.0** (major, per this repo's convention for new features/migrations): adds SPM support alongside CocoaPods, no breaking Dart API changes.
- Bumps `credential_manager` 2.0.8 → **3.0.0** (cascade, depends on `credential_manager_ios ^3.0.0`).
- `credential_manager_android` and `credential_manager_platform_interface` are untouched, still 2.0.8.
- CHANGELOGs updated for both bumped packages.

Builds on #69 (already merged to develop).

## Test plan
- [x] `melos bootstrap` resolves cleanly across the workspace
- [x] `melos run analyze` — no issues
- [x] `melos run format` — all formatted
- [x] docSite type-checks (`tsc --noEmit`) and builds (`npm run build`) with the new doc section
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)