### PR TITLE
docs: revamp docSite UX and fix stale API examples

### DIFF
--- a/docSite/index.html
+++ b/docSite/index.html
@@ -18,6 +18,13 @@
     <meta name="twitter:title" content="Credential Manager Flutter Package" />
     <meta name="twitter:description" content="A Flutter plugin for secure, unified credential management. Supports passkeys, passwords, and federated sign-in on Android and iOS." />
     <meta name="twitter:image" content="https://raw.githubusercontent.com/djsmk123/flutter_credential_manager_compose/main/docSite/og-image.png" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
 
   <body>

--- a/docSite/src/components/BackToTop.tsx
+++ b/docSite/src/components/BackToTop.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { ArrowUp } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const BackToTop = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 480);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <button
+      type="button"
+      aria-label="Back to top"
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      className={cn(
+        'fixed bottom-6 right-6 z-40 flex h-10 w-10 items-center justify-center rounded-full border border-border',
+        'bg-background/90 shadow-md backdrop-blur transition-all duration-300 hover:-translate-y-0.5 hover:bg-accent',
+        visible ? 'translate-y-0 opacity-100' : 'pointer-events-none translate-y-2 opacity-0'
+      )}
+    >
+      <ArrowUp className="h-4 w-4" />
+    </button>
+  );
+};
+
+export default BackToTop;

--- a/docSite/src/components/Breadcrumbs.tsx
+++ b/docSite/src/components/Breadcrumbs.tsx
@@ -1,0 +1,62 @@
+import { Link, useLocation } from 'react-router-dom';
+import { ChevronRight, Clock, Pencil } from 'lucide-react';
+import { docNavGroups, docNavigation } from '@/lib/docs-utils';
+import { useReadingTime } from '@/hooks/useReadingTime';
+
+const GITHUB_EDIT_BASE =
+  'https://github.com/djsmk123/flutter_credential_manager_compose/edit/main/docSite/src/pages/';
+
+interface BreadcrumbsProps {
+  contentId: string;
+}
+
+const Breadcrumbs = ({ contentId }: BreadcrumbsProps) => {
+  const location = useLocation();
+  const current = docNavigation.find((item) => item.path === location.pathname);
+  const group = docNavGroups.find((g) => g.items.some((item) => item.path === location.pathname));
+  const minutes = useReadingTime(contentId);
+
+  if (!current) return null;
+
+  return (
+    <div className="mb-6 flex flex-wrap items-center justify-between gap-3 border-b border-border/60 pb-4">
+      <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm text-muted-foreground">
+        <Link to="/" className="no-underline transition-colors hover:text-foreground">
+          Docs
+        </Link>
+        {group && current.path !== '/' && (
+          <>
+            <ChevronRight className="h-3.5 w-3.5" />
+            <span>{group.label}</span>
+          </>
+        )}
+        {current.path !== '/' && (
+          <>
+            <ChevronRight className="h-3.5 w-3.5" />
+            <span className="font-medium text-foreground">{current.title}</span>
+          </>
+        )}
+      </nav>
+
+      <div className="flex items-center gap-4 text-xs text-muted-foreground">
+        {minutes && (
+          <span className="flex items-center gap-1">
+            <Clock className="h-3.5 w-3.5" />
+            {minutes} min read
+          </span>
+        )}
+        <a
+          href={`${GITHUB_EDIT_BASE}${current.file}`}
+          target="_blank"
+          rel="noreferrer"
+          className="flex items-center gap-1 no-underline transition-colors hover:text-foreground"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+          Edit this page
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default Breadcrumbs;

--- a/docSite/src/components/DocLayout.tsx
+++ b/docSite/src/components/DocLayout.tsx
@@ -7,9 +7,13 @@ import Footer from '@/components/Footer';
 import { cn } from '@/lib/utils';
 import { useSidebarToggle } from '@/hooks/useSidebarToggle';
 import Header from './Header';
-import TableOfContents from './TableOfContents';
+import TableOfContents, { MobileTableOfContents } from './TableOfContents';
+import Breadcrumbs from './Breadcrumbs';
+import BackToTop from './BackToTop';
 
 type DocLayoutProps = PropsWithChildren
+
+const DOC_CONTENT_ID = 'doc-article-content';
 
 const DocLayout = ({ children }: DocLayoutProps) => {
   const { isSidebarOpen, toggleSidebar } = useSidebarToggle();
@@ -21,16 +25,26 @@ const DocLayout = ({ children }: DocLayoutProps) => {
   const prevPage = currentIndex > 0 ? docNavigation[currentIndex - 1] : null;
   const nextPage = currentIndex < docNavigation.length - 1 ? docNavigation[currentIndex + 1] : null;
 
-  // Scroll to top on page change
+  // Scroll to top on page change, and close the mobile drawer so it doesn't linger on navigate
   useEffect(() => {
     window.scrollTo(0, 0);
+    if (isSidebarOpen) toggleSidebar();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname]);
+
+  // Lock body scroll while the mobile drawer is open
+  useEffect(() => {
+    document.body.style.overflow = isSidebarOpen ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isSidebarOpen]);
 
   // Handle scroll progress
   useEffect(() => {
     const handleScroll = () => {
       const totalHeight = document.documentElement.scrollHeight - window.innerHeight;
-      const progress = (window.scrollY / totalHeight) * 100;
+      const progress = totalHeight > 0 ? (window.scrollY / totalHeight) * 100 : 0;
       setScrollProgress(progress);
     };
 
@@ -42,7 +56,7 @@ const DocLayout = ({ children }: DocLayoutProps) => {
     <div className="min-h-screen flex flex-col bg-background font-sans antialiased">
       {/* Progress bar */}
       <div className="fixed top-0 left-0 w-full h-1 z-[100]">
-        <div 
+        <div
           className="h-full bg-primary transition-all duration-300 ease-linear"
           style={{ width: `${scrollProgress}%` }}
         />
@@ -50,20 +64,40 @@ const DocLayout = ({ children }: DocLayoutProps) => {
 
       <Header toggleSidebar={toggleSidebar} isSidebarOpen={isSidebarOpen} />
 
+      {/* Mobile backdrop, dismisses the drawer on tap */}
+      <div
+        aria-hidden="true"
+        onClick={toggleSidebar}
+        className={cn(
+          'fixed inset-0 top-14 z-40 bg-background/80 backdrop-blur-sm transition-opacity md:hidden',
+          isSidebarOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+        )}
+      />
+
       <div className="flex-1 items-start md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-10 container max-w-screen-2xl">
-        <aside className={cn(
-          "fixed top-14 z-30 -ml-2 hidden h-[calc(100vh-3.5rem)] w-full shrink-0 md:sticky md:block overflow-y-auto border-r border-border/40 pr-2 py-6 lg:py-8",
-          isSidebarOpen && "block bg-background inset-0 z-50 w-full p-6 md:p-0"
-        )}>
+        <aside
+          className={cn(
+            'fixed top-14 z-50 h-[calc(100vh-3.5rem)] w-full max-w-xs shrink-0 overflow-y-auto border-r',
+            'border-border/40 bg-background px-6 py-6 shadow-xl transition-transform duration-300 ease-in-out',
+            'md:sticky md:z-30 md:w-full md:max-w-none md:translate-x-0 md:border-r-0 md:bg-transparent',
+            'md:px-0 md:pr-2 md:shadow-none lg:py-8',
+            isSidebarOpen ? 'translate-x-0' : '-translate-x-full'
+          )}
+        >
           <DocSidebar isSidebarOpen={isSidebarOpen} toggleSidebar={toggleSidebar} />
         </aside>
-        
+
         <main className="relative py-6 lg:gap-10 lg:py-8 xl:grid xl:grid-cols-[1fr_300px]">
           <div className="mx-auto w-full min-w-0">
-            <div className={cn(
-              "prose prose-slate dark:prose-invert max-w-none",
-              "animate-fade-in"
-            )}>
+            <Breadcrumbs contentId={DOC_CONTENT_ID} />
+            <MobileTableOfContents />
+            <article
+              id={DOC_CONTENT_ID}
+              className={cn(
+                'prose prose-slate dark:prose-invert max-w-none',
+                'animate-fade-in'
+              )}
+            >
               {children}
 
               {/* Previous/Next navigation */}
@@ -92,12 +126,13 @@ const DocLayout = ({ children }: DocLayoutProps) => {
                   <div />
                 )}
               </div>
-            </div>
+            </article>
             <Footer />
           </div>
           <TableOfContents />
         </main>
       </div>
+      <BackToTop />
     </div>
   );
 };

--- a/docSite/src/components/DocSidebar.tsx
+++ b/docSite/src/components/DocSidebar.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router-dom';
-import { docNavigation } from '@/lib/docs-utils';
+import { docNavGroups } from '@/lib/docs-utils';
 import { cn } from '@/lib/utils';
 
 interface DocSidebarProps {
@@ -7,36 +7,52 @@ interface DocSidebarProps {
   toggleSidebar: () => void;
 }
 
-const DocSidebar = ({}: DocSidebarProps) => {
+const DocSidebar = ({ toggleSidebar }: DocSidebarProps) => {
   const location = useLocation();
-  
-  const isActive = (path: string) => {
-    return location.pathname === path;
-  };
+
+  const isActive = (path: string) => location.pathname === path;
 
   return (
-    <div className="w-full">
-      <div className="pb-4">
-        <h4 className="mb-1 rounded-md px-2 py-1 text-sm font-semibold">
-          Documentation
-        </h4>
-        <div className="grid grid-flow-row auto-rows-max text-sm">
-          {docNavigation.map((item) => (
-            <Link
-              key={item.path}
-              to={item.path}
-              className={cn(
-                "group flex w-full items-center rounded-md border border-transparent px-2 py-1 hover:underline",
-                isActive(item.path)
-                  ? "font-medium text-foreground"
-                  : "text-muted-foreground"
-              )}
-            >
-              {item.title}
-            </Link>
-          ))}
+    <div className="sidebar-wrapper w-full">
+      {docNavGroups.map((group) => (
+        <div key={group.label} className="pb-6">
+          <h4 className="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground/80">
+            {group.label}
+          </h4>
+          <div className="grid grid-flow-row auto-rows-max gap-0.5 text-sm">
+            {group.items.map((item) => {
+              const Icon = item.icon;
+              const active = isActive(item.path);
+              return (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  onClick={() => {
+                    // Close the mobile drawer whenever a destination is picked.
+                    if (window.innerWidth < 768) toggleSidebar();
+                  }}
+                  className={cn(
+                    'group relative flex w-full items-center gap-2.5 rounded-md border border-transparent px-2 py-1.5',
+                    'transition-colors before:absolute before:-left-2 before:top-1/2 before:h-4 before:w-0.5',
+                    'before:-translate-y-1/2 before:rounded-full before:bg-primary before:transition-opacity',
+                    active
+                      ? 'bg-primary/10 font-medium text-primary before:opacity-100'
+                      : 'text-muted-foreground before:opacity-0 hover:bg-accent hover:text-accent-foreground'
+                  )}
+                >
+                  <Icon
+                    className={cn(
+                      'h-4 w-4 shrink-0 transition-colors',
+                      active ? 'text-primary' : 'text-muted-foreground/70 group-hover:text-foreground'
+                    )}
+                  />
+                  <span className="truncate">{item.title}</span>
+                </Link>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      ))}
     </div>
   );
 };

--- a/docSite/src/components/Footer.tsx
+++ b/docSite/src/components/Footer.tsx
@@ -2,7 +2,7 @@ import { Github } from 'lucide-react';
 
 const Footer = () => {
   return (
-    <footer className="bg-slate-50 dark:bg-slate-950/50 border-t border-border mt-auto">
+    <footer className="bg-muted/30 border-t border-border mt-auto">
       <div className="container max-w-screen-2xl py-12 md:py-16">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-12">
           <div className="space-y-4">

--- a/docSite/src/components/Header.tsx
+++ b/docSite/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Github, Menu, X } from 'lucide-react';
+import { Github, Menu, Search, ShieldCheck, X } from 'lucide-react';
 import { ThemeToggle } from './ThemeToggle';
 import { Button } from './ui/button';
 import { useState } from 'react';
@@ -17,42 +17,38 @@ const Header = ({ toggleSidebar, isSidebarOpen }: HeaderProps) => {
   return (
     <>
       <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-        <div className="container flex h-14 max-w-screen-2xl items-center">
-          <div className="mr-4 flex md:hidden">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              onClick={toggleSidebar}
-            >
-              {isSidebarOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
-              <span className="sr-only">Toggle Sidebar</span>
-            </Button>
-          </div>
-          
-          <div className="mr-4 hidden md:flex">
-            <Link to="/" className="mr-6 flex items-center space-x-2">
-              <span className="hidden font-bold sm:inline-block">
-                Flutter Credential Manager
-              </span>
-            </Link>
-          </div>
+        <div className="container flex h-14 max-w-screen-2xl items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="sidebar-toggle h-8 w-8 shrink-0 md:hidden"
+            onClick={toggleSidebar}
+            aria-label="Toggle navigation menu"
+          >
+            {isSidebarOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+          </Button>
 
-          <div className="flex flex-1 items-center justify-between space-x-2 md:justify-end">
-            <div className="w-full flex-1 md:w-auto md:flex-none">
-              <Button
-                variant="outline"
-                className="inline-flex items-center whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input hover:bg-accent hover:text-accent-foreground px-4 py-2 relative h-8 w-full justify-start rounded-[0.5rem] bg-background text-sm font-normal text-muted-foreground shadow-none sm:pr-12 md:w-40 lg:w-64"
-                onClick={() => setIsSearchOpen(true)}
-              >
-                <span className="hidden lg:inline-flex">Search documentation...</span>
-                <span className="inline-flex lg:hidden">Search...</span>
-                <kbd className="pointer-events-none absolute right-[0.3rem] top-[0.3rem] hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">
-                  <span className="text-xs">⌘</span>K
-                </kbd>
-              </Button>
-            </div>
-            
+          <Link to="/" className="mr-4 flex items-center gap-2 shrink-0">
+            <ShieldCheck className="h-5 w-5 text-primary" />
+            <span className="hidden font-bold sm:inline-block">
+              Credential Manager
+            </span>
+          </Link>
+
+          <div className="flex flex-1 items-center justify-end gap-2">
+            <Button
+              variant="outline"
+              className="relative h-9 w-full max-w-[16rem] justify-start gap-2 rounded-lg bg-background text-sm font-normal text-muted-foreground shadow-none sm:pr-12"
+              onClick={() => setIsSearchOpen(true)}
+            >
+              <Search className="h-4 w-4 shrink-0" />
+              <span className="hidden lg:inline-flex">Search documentation...</span>
+              <span className="inline-flex lg:hidden">Search...</span>
+              <kbd className="pointer-events-none absolute right-1.5 top-1/2 hidden -translate-y-1/2 select-none items-center gap-1 rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px] font-medium sm:flex">
+                <span>⌘</span>K
+              </kbd>
+            </Button>
+
             <nav className="flex items-center">
               <Link
                 to="https://github.com/djsmk123/flutter_credential_manager_compose"
@@ -61,7 +57,8 @@ const Header = ({ toggleSidebar, isSidebarOpen }: HeaderProps) => {
               >
                 <div
                   className={cn(
-                    "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground h-9 py-2 w-9 px-0"
+                    'inline-flex h-9 w-9 items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors',
+                    'hover:bg-accent hover:text-accent-foreground'
                   )}
                 >
                   <Github className="h-4 w-4" />

--- a/docSite/src/components/SearchCommand.tsx
+++ b/docSite/src/components/SearchCommand.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
-import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
+import { useEffect, useMemo, useState } from "react";
+import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator } from "@/components/ui/command";
 import { useNavigate } from "react-router-dom";
-import { docNavigation } from "@/lib/docs-utils";
-import { FileText, Laptop, Moon, Sun } from "lucide-react";
+import { docNavGroups } from "@/lib/docs-utils";
+import { searchDocs } from "@/lib/search-index";
+import { Laptop, Moon, SearchX, Sun } from "lucide-react";
 import { useTheme } from "@/components/ThemeProvider";
 
 interface SearchCommandProps {
@@ -13,44 +14,93 @@ interface SearchCommandProps {
 export function SearchCommand({ open, setOpen }: SearchCommandProps) {
   const navigate = useNavigate();
   const { setTheme } = useTheme();
+  const [query, setQuery] = useState("");
 
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        //cant use any
         setOpen(!open);
       }
     };
 
     document.addEventListener("keydown", down);
     return () => document.removeEventListener("keydown", down);
-  }, [setOpen]);
+  }, [open, setOpen]);
+
+  // Reset the query each time the palette is closed, so it opens fresh next time.
+  useEffect(() => {
+    if (!open) setQuery("");
+  }, [open]);
 
   const runCommand = (command: () => void) => {
     setOpen(false);
     command();
   };
 
+  const results = useMemo(() => searchDocs(query), [query]);
+  const isSearching = query.trim().length > 0;
+
   return (
     <CommandDialog open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder="Type a command or search..." />
+      <CommandInput
+        placeholder="Search pages, guides, API names..."
+        value={query}
+        onValueChange={setQuery}
+      />
       <CommandList>
-        <CommandEmpty>No results found.</CommandEmpty>
-        <CommandGroup heading="Documentation">
-          {docNavigation.map((navItem) => (
-            <CommandItem
-              key={navItem.path}
-              value={navItem.title}
-              onSelect={() => {
-                runCommand(() => navigate(navItem.path));
-              }}
-            >
-              <FileText className="mr-2 h-4 w-4" />
-              <span>{navItem.title}</span>
-            </CommandItem>
-          ))}
-        </CommandGroup>
+        {isSearching ? (
+          results.length === 0 ? (
+            <CommandEmpty>
+              <div className="flex flex-col items-center gap-2 py-2 text-muted-foreground">
+                <SearchX className="h-5 w-5" />
+                <span>No results for &quot;{query}&quot;</span>
+              </div>
+            </CommandEmpty>
+          ) : (
+            <CommandGroup heading="Results">
+              {results.map((result, idx) => {
+                const Icon = result.page.icon;
+                return (
+                  <CommandItem
+                    key={`${result.page.path}-${idx}`}
+                    value={`${result.page.path}-${idx}`}
+                    onSelect={() => runCommand(() => navigate(result.page.path))}
+                    className="flex items-start gap-2.5"
+                  >
+                    <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                    <div className="flex flex-col">
+                      <span className="font-medium">{result.page.title}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {result.match === 'section' ? result.sectionText : result.page.description}
+                      </span>
+                    </div>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          )
+        ) : (
+          docNavGroups.map((group) => (
+            <CommandGroup key={group.label} heading={group.label}>
+              {group.items.map((navItem) => {
+                const Icon = navItem.icon;
+                return (
+                  <CommandItem
+                    key={navItem.path}
+                    value={navItem.path}
+                    onSelect={() => runCommand(() => navigate(navItem.path))}
+                    className="flex items-center gap-2.5"
+                  >
+                    <Icon className="h-4 w-4 text-muted-foreground" />
+                    <span>{navItem.title}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          ))
+        )}
+        <CommandSeparator />
         <CommandGroup heading="Theme">
           <CommandItem onSelect={() => runCommand(() => setTheme("light"))}>
             <Sun className="mr-2 h-4 w-4" />

--- a/docSite/src/components/TableOfContents.tsx
+++ b/docSite/src/components/TableOfContents.tsx
@@ -1,99 +1,83 @@
-import { useEffect, useState } from 'react';
-import { cn } from '@/lib/utils';
+import { ChevronDown, ListTree } from 'lucide-react';
 import { useLocation } from 'react-router-dom';
+import { cn } from '@/lib/utils';
+import { buildHeadingUrl, setHeadingHash, useDocHeadings, type TocItem } from '@/hooks/useDocHeadings';
 
-interface TocItem {
-  id: string;
-  text: string;
-  level: number;
+interface TocLinksProps {
+  headings: TocItem[];
+  activeId: string;
+  onSelect: (id: string) => void;
 }
 
-const TableOfContents = () => {
-  const [headings, setHeadings] = useState<TocItem[]>([]);
-  const [activeId, setActiveId] = useState<string>('');
+const TocLinks = ({ headings, activeId, onSelect }: TocLinksProps) => {
   const location = useLocation();
 
-  useEffect(() => {
-    // Small delay to ensure content is rendered
-    const timer = setTimeout(() => {
-      const elements = Array.from(document.querySelectorAll('h2, h3'));
-      
-      const items = elements.map((element) => {
-        // Generate ID if missing
-        if (!element.id) {
-          const slug = element.textContent
-            ?.toLowerCase()
-            .replace(/[^a-z0-9]+/g, '-')
-            .replace(/(^-|-$)+/g, '');
-          element.id = slug || `heading-${Math.random().toString(36).substr(2, 9)}`;
-        }
+  return (
+    <ul className="m-0 list-none space-y-2">
+      {headings.map((heading) => (
+        <li key={heading.id} className="mt-0">
+          <a
+            href={`#${buildHeadingUrl(location.pathname, location.search, heading.id)}`}
+            onClick={(e) => {
+              e.preventDefault();
+              document.getElementById(heading.id)?.scrollIntoView({ behavior: 'smooth' });
+              onSelect(heading.id);
+              setHeadingHash(location.pathname, location.search, heading.id);
+            }}
+            className={cn(
+              'inline-block no-underline transition-colors hover:text-foreground text-sm',
+              heading.level === 3 && 'pl-4',
+              activeId === heading.id ? 'font-medium text-primary' : 'text-muted-foreground'
+            )}
+          >
+            {heading.text}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+};
 
-        return {
-          id: element.id,
-          text: element.textContent || '',
-          level: Number(element.tagName.substring(1)),
-        };
-      });
-
-      setHeadings(items);
-
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              setActiveId(entry.target.id);
-            }
-          });
-        },
-        { rootMargin: '0px 0px -80% 0px' }
-      );
-
-      elements.forEach((element) => {
-        observer.observe(element);
-      });
-
-      return () => observer.disconnect();
-    }, 100); // 100ms delay to allow for rendering
-
-    return () => clearTimeout(timer);
-  }, [location.pathname]); // Re-run when path changes
+// Sticky right-hand rail shown on wide (xl+) viewports.
+const TableOfContents = () => {
+  const { headings, activeId, setActiveId } = useDocHeadings();
 
   if (headings.length === 0) return null;
 
   return (
     <div className="hidden xl:block">
-      <div className="sticky top-20 -mt-10 h-[calc(100vh-3.5rem)] overflow-hidden pt-6">
-        <div className="space-y-2">
-          <p className="font-medium text-sm text-foreground">On This Page</p>
-          <ul className="m-0 list-none">
-            {headings.map((heading) => (
-              <li key={heading.id} className="mt-0 pt-2">
-                <a
-                  href={`#${heading.id}`}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    document.getElementById(heading.id)?.scrollIntoView({
-                      behavior: 'smooth'
-                    });
-                    setActiveId(heading.id);
-                    window.history.pushState(null, '', `#${heading.id}`);
-                  }}
-                  className={cn(
-                    "inline-block no-underline transition-colors hover:text-foreground text-sm",
-                    heading.level === 3 && "pl-4",
-                    activeId === heading.id
-                      ? "font-medium text-foreground"
-                      : "text-muted-foreground"
-                  )}
-                >
-                  {heading.text}
-                </a>
-              </li>
-            ))}
-          </ul>
+      <div className="sticky top-20 -mt-10 h-[calc(100vh-3.5rem)] overflow-y-auto pt-6">
+        <div className="space-y-3">
+          <p className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+            <ListTree className="h-3.5 w-3.5" />
+            On This Page
+          </p>
+          <TocLinks headings={headings} activeId={activeId} onSelect={setActiveId} />
         </div>
       </div>
     </div>
+  );
+};
+
+// Collapsible "On this page" panel for mobile/tablet, where the rail is hidden.
+export const MobileTableOfContents = () => {
+  const { headings, activeId, setActiveId } = useDocHeadings();
+
+  if (headings.length === 0) return null;
+
+  return (
+    <details className="group/toc mb-8 rounded-lg border border-border bg-muted/30 xl:hidden">
+      <summary className="flex cursor-pointer list-none items-center justify-between px-4 py-3 text-sm font-medium marker:content-none [&::-webkit-details-marker]:hidden">
+        <span className="flex items-center gap-1.5">
+          <ListTree className="h-3.5 w-3.5" />
+          On this page
+        </span>
+        <ChevronDown className="h-4 w-4 transition-transform group-open/toc:rotate-180" />
+      </summary>
+      <div className="border-t border-border/60 px-4 pb-4 pt-3">
+        <TocLinks headings={headings} activeId={activeId} onSelect={setActiveId} />
+      </div>
+    </details>
   );
 };
 

--- a/docSite/src/hooks/useDocHeadings.ts
+++ b/docSite/src/hooks/useDocHeadings.ts
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export interface TocItem {
+  id: string;
+  text: string;
+  level: number;
+}
+
+const ANCHOR_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" ' +
+  'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+  '<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>' +
+  '<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>';
+
+// The app uses HashRouter (required for GitHub Pages, which has no server-side rewrite rules),
+// so the URL fragment after the FIRST '#' is the router's whole world — it's parsed as
+// pathname+search. A bare `#heading-id` therefore gets misread as a route path ("/heading-id")
+// and 404s. Deep-linkable headings instead go in a `?heading=` query param inside that fragment,
+// e.g. `#/usage?heading=google-sign-in`, which the router parses correctly as pathname "/usage".
+export function buildHeadingUrl(routePath: string, routeSearch: string, id: string) {
+  const params = new URLSearchParams(routeSearch);
+  params.set('heading', id);
+  return `${routePath}?${params.toString()}`;
+}
+
+// Updates the address bar to a deep-linkable heading URL without disturbing router state
+// (replaceState doesn't fire hashchange, so React Router's own location stays put — fine here
+// since scrolling is handled manually and the URL only needs to be correct for sharing/refresh).
+export function setHeadingHash(routePath: string, routeSearch: string, id: string) {
+  const hash = buildHeadingUrl(routePath, routeSearch, id);
+  window.history.replaceState(null, '', `${window.location.pathname}#${hash}`);
+}
+
+// Scrapes h2/h3 headings inside the doc article for the TOC, assigns stable ids, and
+// progressively enhances each heading with a hover-to-copy anchor link (docs sites like
+// this render headings as plain JSX per-page, so there's no markdown pipeline to hook into).
+export function useDocHeadings() {
+  const [headings, setHeadings] = useState<TocItem[]>([]);
+  const [activeId, setActiveId] = useState<string>('');
+  const location = useLocation();
+  const hasScrolledToDeepLink = useRef(false);
+
+  useEffect(() => {
+    hasScrolledToDeepLink.current = false;
+  }, [location.pathname]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const elements = Array.from(document.querySelectorAll<HTMLElement>('article h2, article h3'));
+
+      const items = elements.map((element) => {
+        const text = element.textContent?.trim() || '';
+
+        if (!element.id) {
+          const slug = text
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/(^-|-$)+/g, '');
+          element.id = slug || `heading-${Math.random().toString(36).slice(2, 11)}`;
+        }
+
+        if (!element.dataset.anchorEnhanced) {
+          element.dataset.anchorEnhanced = 'true';
+          element.classList.add('group/heading', 'relative');
+
+          const anchor = document.createElement('a');
+          anchor.setAttribute('aria-label', `Link to ${text || 'section'}`);
+          anchor.className =
+            'heading-anchor absolute -left-5 top-1/2 hidden -translate-y-1/2 text-muted-foreground ' +
+            'hover:text-primary transition-colors no-underline md:group-hover/heading:inline-flex';
+          anchor.innerHTML = ANCHOR_SVG;
+          anchor.addEventListener('click', (event) => {
+            event.preventDefault();
+            const shareUrl = `${window.location.origin}${window.location.pathname}#${buildHeadingUrl(
+              location.pathname,
+              location.search,
+              element.id
+            )}`;
+            navigator.clipboard?.writeText(shareUrl).catch(() => undefined);
+            setHeadingHash(location.pathname, location.search, element.id);
+            element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          });
+          anchor.href = `#${buildHeadingUrl(location.pathname, location.search, element.id)}`;
+          element.prepend(anchor);
+        }
+
+        return {
+          id: element.id,
+          text,
+          level: Number(element.tagName.substring(1)),
+        };
+      });
+
+      setHeadings(items);
+
+      // Deep link support: `#/usage?heading=id` scrolls to that heading once on load.
+      if (!hasScrolledToDeepLink.current) {
+        const targetId = new URLSearchParams(location.search).get('heading');
+        const target = targetId ? document.getElementById(targetId) : null;
+        if (target) {
+          target.scrollIntoView({ block: 'start' });
+          setActiveId(target.id);
+        }
+        hasScrolledToDeepLink.current = true;
+      }
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              setActiveId(entry.target.id);
+            }
+          });
+        },
+        { rootMargin: '0px 0px -80% 0px' }
+      );
+
+      elements.forEach((element) => observer.observe(element));
+
+      return () => observer.disconnect();
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, [location.pathname, location.search]);
+
+  return { headings, activeId, setActiveId };
+}

--- a/docSite/src/hooks/useReadingTime.ts
+++ b/docSite/src/hooks/useReadingTime.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const WORDS_PER_MINUTE = 200;
+
+// Estimates reading time from the rendered word count of a container, re-measured on navigation.
+export function useReadingTime(containerId: string) {
+  const [minutes, setMinutes] = useState<number | null>(null);
+  const location = useLocation();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const el = document.getElementById(containerId);
+      if (!el) return;
+      const words = el.textContent?.trim().split(/\s+/).filter(Boolean).length ?? 0;
+      setMinutes(Math.max(1, Math.round(words / WORDS_PER_MINUTE)));
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, [location.pathname, containerId]);
+
+  return minutes;
+}

--- a/docSite/src/index.css
+++ b/docSite/src/index.css
@@ -13,7 +13,7 @@
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
 
-    --primary: 222.2 47.4% 11.2%;
+    --primary: 217 91% 60%;
     --primary-foreground: 210 40% 98%;
 
     --secondary: 210 40% 96.1%;
@@ -30,7 +30,10 @@
 
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --ring: 217 91% 60%;
+
+    --brand-glow-1: 217 91% 60%;
+    --brand-glow-2: 262 83% 68%;
 
     --radius: 0.5rem;
 
@@ -56,7 +59,7 @@
     --popover: 222.2 47.4% 11.2%;
     --popover-foreground: 210 40% 98%;
 
-    --primary: 210 40% 98%;
+    --primary: 213 94% 68%;
     --primary-foreground: 222.2 47.4% 11.2%;
 
     --secondary: 217.2 32.6% 17.5%;
@@ -73,7 +76,10 @@
 
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --ring: 213 94% 68%;
+
+    --brand-glow-1: 213 94% 68%;
+    --brand-glow-2: 262 83% 74%;
 
     --sidebar-background: 222.2 47.4% 11.2%;
     --sidebar-foreground: 210 40% 98%;
@@ -96,13 +102,17 @@
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 
+  ::selection {
+    @apply bg-primary/25 text-foreground;
+  }
+
   h1,
   h2,
   h3,
   h4,
   h5,
   h6 {
-    @apply scroll-mt-24 font-semibold tracking-tight;
+    @apply scroll-mt-24 font-bold tracking-tight;
   }
 
   h1 {
@@ -110,11 +120,11 @@
   }
 
   h2 {
-    @apply text-3xl border-b pb-2 mt-10 mb-4;
+    @apply text-2xl md:text-3xl border-b border-border/70 pb-3 mt-12 mb-4;
   }
 
   h3 {
-    @apply text-2xl mt-8 mb-4;
+    @apply text-xl md:text-2xl mt-8 mb-3;
   }
 
   p {
@@ -261,7 +271,7 @@ pre[class*="language-"] {
 }
 
 .prose table {
-  @apply w-full my-8 border-collapse text-sm;
+  @apply w-full my-8 border-collapse overflow-hidden rounded-lg border border-border text-sm;
 }
 
 .prose thead {
@@ -278,4 +288,36 @@ pre[class*="language-"] {
 
 .prose tr:last-child td {
   @apply border-0;
+}
+
+.prose tbody tr {
+  @apply transition-colors hover:bg-muted/30;
+}
+
+.prose h1:first-child,
+.prose h2:first-child {
+  @apply mt-0;
+}
+
+/* Hero background: soft radial brand glow + faint grid, used on the homepage */
+.hero-glow {
+  background-image:
+    radial-gradient(60% 50% at 15% 0%, hsl(var(--brand-glow-1) / 0.18), transparent 70%),
+    radial-gradient(50% 40% at 85% 10%, hsl(var(--brand-glow-2) / 0.16), transparent 70%);
+}
+
+.hero-grid {
+  background-image: theme('backgroundImage.grid-pattern');
+  background-size: 42px 42px;
+  -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, black 40%, transparent 100%);
+  mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, black 40%, transparent 100%);
+}
+
+.gradient-text {
+  @apply bg-clip-text text-transparent;
+  background-image: linear-gradient(to right, hsl(var(--brand-glow-1)), hsl(var(--brand-glow-2)));
+}
+
+.card-hover {
+  @apply transition-all duration-300 hover:-translate-y-1 hover:border-primary/40 hover:shadow-glow;
 }

--- a/docSite/src/lib/docs-utils.ts
+++ b/docSite/src/lib/docs-utils.ts
@@ -1,59 +1,84 @@
 
-import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import type { LucideIcon } from 'lucide-react';
+import {
+  Home,
+  Download,
+  Settings,
+  BookOpen,
+  Code2,
+  Sparkles,
+  HelpCircle,
+  Users,
+  History,
+  ArrowUpRightFromCircle,
+  Newspaper,
+} from 'lucide-react';
 
-// Define the navigation structure
-export const docNavigation = [
-  { title: 'Home', path: '/' },
-  { title: 'Installation', path: '/installation' },
-  { title: 'Configuration', path: '/configuration' },
-  { title: 'Usage', path: '/usage' },
-  { title: 'API Reference', path: '/api-reference' },
-  { title: 'Examples', path: '/examples' },
-  { title: 'FAQ', path: '/faq' },
-  { title: 'Contributing', path: '/contributing' },
-  { title: 'Changelog', path: '/changelog' },
-  { title: 'Migration', path: '/migration' },
-  { title: 'Blogs', path: '/blogs' },
-  { title: 'React Native', path: '/react-native' }
+export interface DocNavItem {
+  title: string;
+  path: string;
+  icon: LucideIcon;
+  description: string;
+  /** Path relative to docSite/src/pages, used to build "Edit this page" links. */
+  file: string;
+}
+
+export interface DocNavGroup {
+  label: string;
+  items: DocNavItem[];
+}
+
+// Grouped navigation structure, used by the sidebar, search index, and prev/next pagination.
+export const docNavGroups: DocNavGroup[] = [
+  {
+    label: 'Getting Started',
+    items: [
+      { title: 'Home', path: '/', icon: Home, description: 'Overview of the plugin and its features.', file: 'HomePage.tsx' },
+      { title: 'Installation', path: '/installation', icon: Download, description: 'Add the package to your Flutter project.', file: 'InstallationPage.tsx' },
+      { title: 'Configuration', path: '/configuration', icon: Settings, description: 'Android and iOS native setup.', file: 'ConfigurationPage.tsx' },
+    ],
+  },
+  {
+    label: 'Guides',
+    items: [
+      { title: 'Usage', path: '/usage', icon: BookOpen, description: 'Core APIs for saving and retrieving credentials.', file: 'UsagePage.tsx' },
+      { title: 'Examples', path: '/examples', icon: Sparkles, description: 'Copy-paste recipes for common flows.', file: 'ExamplesPage.tsx' },
+      { title: 'Migration', path: '/migration', icon: ArrowUpRightFromCircle, description: 'Upgrading between major versions.', file: 'MigrationPage.tsx' },
+    ],
+  },
+  {
+    label: 'Reference',
+    items: [
+      { title: 'API Reference', path: '/api-reference', icon: Code2, description: 'Full class and method reference.', file: 'ApiReferencePage.tsx' },
+      { title: 'FAQ', path: '/faq', icon: HelpCircle, description: 'Answers to common questions.', file: 'FaqPage.tsx' },
+      { title: 'React Native', path: '/react-native', icon: Newspaper, description: 'Status of React Native support.', file: 'ReactNativePage.tsx' },
+    ],
+  },
+  {
+    label: 'Community',
+    items: [
+      { title: 'Contributing', path: '/contributing', icon: Users, description: 'How to contribute to the project.', file: 'ContributingPage.tsx' },
+      { title: 'Changelog', path: '/changelog', icon: History, description: 'Release history and version notes.', file: 'ChangelogPage.tsx' },
+      { title: 'Blogs', path: '/blogs', icon: Newspaper, description: 'Articles and write-ups.', file: 'BlogsPage.tsx' },
+    ],
+  },
 ];
 
-// Hook to check if sidebar should be open on mobile
-export function useSidebarToggle() {
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  
-  const toggleSidebar = () => {
-    setIsSidebarOpen(!isSidebarOpen);
-  };
-  
-  // Close sidebar when clicking outside on mobile
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (isSidebarOpen && (event.target as HTMLElement).closest('.sidebar-wrapper') === null && (event.target as HTMLElement).closest('.sidebar-toggle') === null) {
-        setIsSidebarOpen(false);
-      }
-    };
-    
-    document.addEventListener('click', handleClickOutside);
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  }, [isSidebarOpen]);
-  
-  return { isSidebarOpen, toggleSidebar };
-}
+// Flattened navigation list, kept for callers that only need path/title (prev/next, search).
+export const docNavigation: DocNavItem[] = docNavGroups.flatMap((group) => group.items);
 
 // Hook to get current path and highlight active nav item
 export function useActiveNavItem() {
   const location = useLocation();
-  
+
   const isActive = (path: string) => {
     if (path === '/') {
       return location.pathname === '/';
     }
     return location.pathname.startsWith(path);
   };
-  
+
   return { isActive };
 }
 

--- a/docSite/src/lib/search-index.ts
+++ b/docSite/src/lib/search-index.ts
@@ -1,0 +1,149 @@
+import { docNavGroups, type DocNavItem } from './docs-utils';
+
+export interface SearchSection {
+  /** Heading or topic text shown/matched as a sub-result under its parent page. */
+  text: string;
+  /** Optional anchor id to deep-link to, when it matches the slug the page will generate. */
+  anchor?: string;
+}
+
+// Hand-maintained per-page topic index (headings, FAQ questions, key API names) so search can
+// match more than just the page title. Pages render headings as plain JSX rather than markdown,
+// so there's no build-time content pipeline to source this from automatically.
+const sectionsByPath: Record<string, SearchSection[]> = {
+  '/': [
+    { text: 'Secure Storage' },
+    { text: 'Biometric Auth' },
+    { text: 'Cross Platform' },
+  ],
+  '/installation': [
+    { text: 'pubspec.yaml' },
+    { text: 'Next Steps' },
+  ],
+  '/configuration': [
+    { text: 'Android Configuration' },
+    { text: 'Proguard Rules' },
+    { text: 'Gradle Configuration' },
+    { text: 'Digital Asset Links Setup' },
+    { text: 'Google Sign-In Setup' },
+    { text: 'iOS Configuration' },
+    { text: 'Swift Package Manager (SPM) Support' },
+    { text: 'Enabling Password AutoFill' },
+    { text: 'Keychain Group' },
+    { text: 'Apple App Site Association File Example' },
+  ],
+  '/usage': [
+    { text: 'Initialize Credential Manager' },
+    { text: 'Password Based Credentials' },
+    { text: 'Google Sign-In (Only For Android)' },
+    { text: 'Setup Google Cloud Console' },
+    { text: 'Sign-In with Google' },
+    { text: 'Passkey' },
+    { text: 'Passkey Setup for Android' },
+    { text: 'Create Passkey Credentials' },
+    { text: 'Get Passkey Credentials' },
+    { text: 'Logout' },
+    { text: 'Error Handling' },
+    { text: 'Platform Support' },
+  ],
+  '/api-reference': [
+    { text: 'CredentialManager' },
+    { text: 'PasswordCredential' },
+    { text: 'PublicKeyCredential' },
+    { text: 'GoogleIdTokenCredential' },
+    { text: 'CredentialCreationOptions' },
+    { text: 'CredentialLoginOptions' },
+    { text: 'FetchOptionsAndroid' },
+    { text: 'CredentialException' },
+    { text: 'savePasswordCredentials' },
+    { text: 'savePasskeyCredentials' },
+    { text: 'getCredentials' },
+    { text: 'saveGoogleCredential' },
+  ],
+  '/examples': [
+    { text: "What's New in the Example App" },
+    { text: 'Gate Google Sign-In When Play Services Are Missing' },
+    { text: 'Inspect Credential Payloads with JsonViewer' },
+    { text: 'Password Credential Example' },
+    { text: 'Passkey Example' },
+    { text: 'Google Sign-In Example' },
+  ],
+  '/migration': [
+    { text: 'Password Credentials' },
+    { text: 'Passkey Credentials' },
+    { text: 'Google Sign-In Credentials' },
+    { text: 'V1 Code' },
+    { text: 'V2 Code' },
+  ],
+  '/faq': [
+    { text: 'What is Credential Manager?' },
+    { text: 'What is Keychain?' },
+    { text: 'What is ASAuthorizationController?' },
+    { text: 'How do I clone the repository?' },
+    { text: 'How do I initialize Credential Manager?' },
+    { text: 'How do I save password-based credentials on Android?' },
+    { text: 'How do handle errors?' },
+    { text: 'How do I logout?' },
+  ],
+  '/contributing': [
+    { text: 'Ways to Contribute' },
+    { text: 'Getting Started' },
+    { text: 'Code Style Guidelines' },
+    { text: 'Pull Request Guidelines' },
+    { text: 'Issue Guidelines' },
+    { text: 'Code of Conduct' },
+  ],
+  '/changelog': [
+    { text: 'Release notes' },
+    { text: 'Version history' },
+    { text: 'Breaking changes' },
+  ],
+  '/blogs': [
+    { text: 'Write a Blog About This Package' },
+    { text: 'Related Resources' },
+  ],
+  '/react-native': [
+    { text: 'React Native Alternatives' },
+    { text: 'Android Alternatives' },
+    { text: 'iOS Alternatives' },
+    { text: 'Passkey Support in React Native' },
+  ],
+};
+
+export interface SearchResult {
+  page: DocNavItem;
+  groupLabel: string;
+  match: 'title' | 'description' | 'section';
+  sectionText?: string;
+}
+
+const allPages = docNavGroups.flatMap((group) =>
+  group.items.map((item) => ({ item, groupLabel: group.label }))
+);
+
+export function searchDocs(query: string): SearchResult[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+
+  const results: SearchResult[] = [];
+
+  for (const { item, groupLabel } of allPages) {
+    if (item.title.toLowerCase().includes(q)) {
+      results.push({ page: item, groupLabel, match: 'title' });
+      continue;
+    }
+
+    if (item.description.toLowerCase().includes(q)) {
+      results.push({ page: item, groupLabel, match: 'description' });
+      continue;
+    }
+
+    const sections = sectionsByPath[item.path] ?? [];
+    const matchedSection = sections.find((s) => s.text.toLowerCase().includes(q));
+    if (matchedSection) {
+      results.push({ page: item, groupLabel, match: 'section', sectionText: matchedSection.text });
+    }
+  }
+
+  return results;
+}

--- a/docSite/src/pages/ApiReferencePage.tsx
+++ b/docSite/src/pages/ApiReferencePage.tsx
@@ -64,7 +64,7 @@ const ApiReferencePage = () => {
             <td className="border border-gray-300 px-4 py-2">Initializes the credential manager with optional parameters.</td>
           </tr>
           <tr>
-            <td className="border border-gray-300 px-4 py-2 font-mono text-sm">savePasswordCredential()</td>
+            <td className="border border-gray-300 px-4 py-2 font-mono text-sm">savePasswordCredentials()</td>
             <td className="border border-gray-300 px-4 py-2">Saves password-based credentials.</td>
           </tr>
           <tr>

--- a/docSite/src/pages/ChangelogPage.tsx
+++ b/docSite/src/pages/ChangelogPage.tsx
@@ -6,6 +6,20 @@
 
 const changelog = [
   {
+    version: "3.0.1",
+    items: [
+      <>Bumped <code>credential_manager_ios</code> to <code>^3.0.1</code> and <code>credential_manager_android</code> to <code>^3.0.1</code>, both of which add native static analysis (SwiftLint, Detekt) with no functional or API changes.</>,
+      "No breaking changes to the Dart API.",
+    ],
+  },
+  {
+    version: "3.0.0",
+    items: [
+      <>Bumped <code>credential_manager_ios</code> to <code>^3.0.0</code>, which adds Swift Package Manager (SPM) support alongside the existing CocoaPods integration.</>,
+      "No breaking changes to the Dart API; apps still on CocoaPods continue to work unchanged.",
+    ],
+  },
+  {
     version: "2.0.8",
     items: [
       <>Added <code>isGmsAvailable</code> to platform interface.</>,

--- a/docSite/src/pages/ConfigurationPage.tsx
+++ b/docSite/src/pages/ConfigurationPage.tsx
@@ -170,8 +170,7 @@ pod deintegrate`}
       <h3 className="mt-6 mb-2">Enabling Password AutoFill</h3>
 
       <ol className="list-decimal pl-6 mb-6">
-        <li className="mb-2">Open your project in XcoIn the Associated Domains section, add the domain that you want to associate with your app using the format applinks:yourdomain.com and webcredentials:yourdomain.com.
-        de.</li>
+        <li className="mb-2">Open your project in Xcode.</li>
         <li className="mb-2">Go to your app target &gt; Signing & Capabilities tab.</li>
         <li className="mb-2">Click "+" and select <strong>Associated Domains</strong>.</li>
         <li className="mb-2">Add domains like <code>applinks:yourdomain.com</code> and <code>webcredentials:yourdomain.com</code>.</li>

--- a/docSite/src/pages/ExamplesPage.tsx
+++ b/docSite/src/pages/ExamplesPage.tsx
@@ -99,7 +99,7 @@ await credentialManager.init(
         language="dart"
         code={`// Save Password Credential
 try {
-  await credentialManager.savePasswordCredential(
+  await credentialManager.savePasswordCredentials(
     PasswordCredential(
       username: emailController.text,
       password: passwordController.text,
@@ -170,12 +170,12 @@ try {
     "id": credential.id,
     "rawId": credential.rawId,
     "type": credential.type,
-    "clientDataJSON": credential.clientDataJSON,
+    "clientDataJSON": credential.response?.clientDataJSON,
     "attestationObject": credential.response?.attestationObject,
     "authenticatorData": credential.response?.authenticatorData,
-    "publicKey": credential.response?.publicKey,
-    "publicKeyAlgorithm": credential.response?.publicKeyAlgorithm,
-    "transports": credential.response?.transports,
+    "publicKey": credential.publicKey,
+    "publicKeyAlgorithm": credential.publicKeyAlgorithm,
+    "transports": credential.transports,
   };
 
   // TODO: Send registrationResponse to your server

--- a/docSite/src/pages/FaqPage.tsx
+++ b/docSite/src/pages/FaqPage.tsx
@@ -98,13 +98,13 @@ if (credentialManager.isSupportedPlatform) {
           </div>
           <div className="border-t border-gray-200 px-4 py-5 sm:px-6">
             <p className="text-sm text-gray-500">
-              To save password-based credentials on Android, use the <code>savePasswordCredential</code> method of the <code>CredentialManager</code> object. Wrap the call in a try-catch block to handle any potential errors.
+              To save password-based credentials on Android, use the <code>savePasswordCredentials</code> method of the <code>CredentialManager</code> object. Wrap the call in a try-catch block to handle any potential errors.
             </p>
             <pre className="bg-gray-100 p-4 rounded-md overflow-x-auto mt-4">
                 <CodeBlock
                   language="dart"
                   code={`try {
-  await credentialManager.savePasswordCredential(
+  await credentialManager.savePasswordCredentials(
     PasswordCredential(
       username: '1234567890',
       password: 'password',

--- a/docSite/src/pages/HomePage.tsx
+++ b/docSite/src/pages/HomePage.tsx
@@ -1,106 +1,141 @@
 import { Link } from 'react-router-dom';
-import { ArrowRight, Shield, Lock, Smartphone, Zap } from 'lucide-react';
+import { ArrowRight, Fingerprint, KeyRound, ShieldCheck, Smartphone, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import CodeBlock from '@/components/CodeBlock';
+
+const features = [
+  {
+    icon: ShieldCheck,
+    title: 'Secure Storage',
+    description:
+      'Leverages platform-specific secure storage mechanisms (Keychain on iOS, Keystore on Android) to keep data safe.',
+    accent: 'text-blue-500 bg-blue-500/10',
+  },
+  {
+    icon: Fingerprint,
+    title: 'Biometric Auth',
+    description: 'Seamlessly integrate biometric authentication (Face ID, Touch ID, Fingerprint) for access control.',
+    accent: 'text-violet-500 bg-violet-500/10',
+  },
+  {
+    icon: Smartphone,
+    title: 'Cross Platform',
+    description: 'One unified Dart API for both iOS and Android, handling platform differences automatically.',
+    accent: 'text-emerald-500 bg-emerald-500/10',
+  },
+  {
+    icon: KeyRound,
+    title: 'Passkeys Built-In',
+    description: 'First-class support for FIDO2 passkeys alongside traditional password credentials.',
+    accent: 'text-amber-500 bg-amber-500/10',
+  },
+];
 
 const HomePage = () => {
   return (
     <div className="flex flex-col gap-16 pb-8">
       {/* Hero Section */}
-      <section className="flex flex-col items-start gap-4 pt-8 md:pt-12 lg:pt-24">
-        <div className="inline-flex items-center rounded-lg bg-muted px-3 py-1 text-sm font-medium">
-          🎉 <span className="ml-1">v1.0.0 is now available</span>
+      <section className="hero-glow relative -mx-4 flex flex-col items-start gap-5 overflow-hidden px-4 pt-8 md:pt-14 lg:pt-24">
+        <div className="hero-grid pointer-events-none absolute inset-0 -z-10" />
+
+        <div className="inline-flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
+          <Sparkles className="h-3.5 w-3.5" />
+          v3.0.1 is now available
         </div>
-        <h1 className="text-3xl font-bold leading-tight tracking-tighter md:text-5xl lg:leading-[1.1]">
+
+        <h1 className="text-3xl font-extrabold leading-tight tracking-tighter md:text-5xl lg:leading-[1.1]">
           Secure Credential Management <br className="hidden sm:inline" />
-          for Flutter Applications
+          for <span className="gradient-text">Flutter Applications</span>
         </h1>
+
         <p className="max-w-[750px] text-lg text-muted-foreground sm:text-xl">
-          A powerful, easy-to-use plugin for managing user credentials in Flutter. 
-          Securely store, retrieve, and manage authentication tokens with biometric support.
+          A powerful, easy-to-use plugin for managing user credentials in Flutter.
+          Securely store, retrieve, and manage passwords, passkeys, and Google sign-in.
         </p>
-        <div className="flex w-full items-center gap-4 md:w-auto">
-          <Link to="/installation">
-            <Button size="lg" className="w-full md:w-auto gap-2">
+
+        <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center md:w-auto">
+          <Link to="/installation" className="w-full sm:w-auto">
+            <Button size="lg" className="w-full gap-2 shadow-glow sm:w-auto">
               Get Started <ArrowRight className="h-4 w-4" />
             </Button>
           </Link>
-          <Link to="/examples">
-            <Button variant="outline" size="lg" className="w-full md:w-auto">
+          <Link to="/examples" className="w-full sm:w-auto">
+            <Button variant="outline" size="lg" className="w-full sm:w-auto">
               View Examples
             </Button>
           </Link>
         </div>
+
+        <div className="mt-2 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <ShieldCheck className="h-4 w-4 text-primary" /> Android &amp; iOS
+          </span>
+          <span className="flex items-center gap-1.5">
+            <KeyRound className="h-4 w-4 text-primary" /> Passkeys (FIDO2)
+          </span>
+          <span className="flex items-center gap-1.5">
+            <Fingerprint className="h-4 w-4 text-primary" /> Biometric unlock
+          </span>
+        </div>
       </section>
 
       {/* Features Grid */}
-      <section className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-        <div className="relative overflow-hidden rounded-lg border bg-background p-6 hover:border-primary/50 transition-colors">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 mb-4">
-            <Shield className="h-6 w-6 text-primary" />
+      <section className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+        {features.map(({ icon: Icon, title, description, accent }) => (
+          <div
+            key={title}
+            className="card-hover relative overflow-hidden rounded-xl border border-border bg-card p-6"
+          >
+            <div className={`mb-4 flex h-11 w-11 items-center justify-center rounded-lg ${accent}`}>
+              <Icon className="h-5 w-5" />
+            </div>
+            <h3 className="mb-2 text-lg font-bold">{title}</h3>
+            <p className="text-sm text-muted-foreground">{description}</p>
           </div>
-          <h3 className="font-bold text-xl mb-2">Secure Storage</h3>
-          <p className="text-muted-foreground">
-            Leverages platform-specific secure storage mechanisms (Keychain on iOS, Keystore on Android) to keep data safe.
-          </p>
-        </div>
-        <div className="relative overflow-hidden rounded-lg border bg-background p-6 hover:border-primary/50 transition-colors">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 mb-4">
-            <Lock className="h-6 w-6 text-primary" />
-          </div>
-          <h3 className="font-bold text-xl mb-2">Biometric Auth</h3>
-          <p className="text-muted-foreground">
-            Seamlessly integrate biometric authentication (Face ID, Touch ID, Fingerprint) for access control.
-          </p>
-        </div>
-        <div className="relative overflow-hidden rounded-lg border bg-background p-6 hover:border-primary/50 transition-colors">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 mb-4">
-            <Smartphone className="h-6 w-6 text-primary" />
-          </div>
-          <h3 className="font-bold text-xl mb-2">Cross Platform</h3>
-          <p className="text-muted-foreground">
-            Unified API for both iOS and Android, handling platform differences automatically.
-          </p>
-        </div>
+        ))}
       </section>
 
       {/* Code Preview Section */}
-      <section className="rounded-xl border bg-muted/50 p-8">
+      <section className="rounded-xl border border-border bg-muted/30 p-6 md:p-8">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
-            <h2 className="text-2xl font-bold">Simple & Intuitive API</h2>
-            <p className="text-muted-foreground mt-2">
+            <h2 className="text-2xl font-bold">Simple &amp; Intuitive API</h2>
+            <p className="mt-2 text-muted-foreground">
               Designed to be easy to integrate into your existing Flutter apps.
             </p>
           </div>
         </div>
-        <div className="mt-8 relative rounded-lg bg-slate-950 p-4 overflow-hidden">
-          <pre className="text-sm text-slate-50 overflow-x-auto">
-            <code>{`// Save credentials
-await CredentialManager.save(
-  key: 'user_token',
-  value: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+        <div className="mt-6">
+          <CodeBlock
+            language="dart"
+            code={`final credentialManager = CredentialManager();
+await credentialManager.init(preferImmediatelyAvailableCredentials: true);
+
+// Save a password credential
+await credentialManager.savePasswordCredentials(
+  PasswordCredential(username: 'user@example.com', password: 'hunter2'),
 );
 
-// Retrieve credentials
-final token = await CredentialManager.read(key: 'user_token');
+// Retrieve saved credentials
+final credentials = await credentialManager.getCredentials();
 
-// Delete credentials
-await CredentialManager.delete(key: 'user_token');`}</code>
-          </pre>
+// Sign out / clear state
+await credentialManager.logout();`}
+          />
         </div>
       </section>
 
       {/* CTA Section */}
-      <section className="flex flex-col items-center gap-4 py-8 md:py-12 lg:py-24 text-center">
-        <h2 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl">
+      <section className="hero-glow relative -mx-4 flex flex-col items-center gap-4 overflow-hidden rounded-2xl border border-border px-4 py-12 text-center md:py-20">
+        <h2 className="text-3xl font-extrabold tracking-tighter sm:text-4xl md:text-5xl">
           Ready to secure your app?
         </h2>
         <p className="max-w-[600px] text-muted-foreground md:text-xl">
-          Join thousands of developers building secure Flutter applications with Credential Manager.
+          Join developers building secure Flutter applications with Credential Manager.
         </p>
         <Link to="/installation">
-          <Button size="lg" className="mt-4">
-            Start Integration
+          <Button size="lg" className="mt-4 gap-2 shadow-glow">
+            Start Integration <ArrowRight className="h-4 w-4" />
           </Button>
         </Link>
       </section>

--- a/docSite/src/pages/MigrationPage.tsx
+++ b/docSite/src/pages/MigrationPage.tsx
@@ -29,7 +29,7 @@ const MigrationPage = () => {
                 <CodeBlock 
                   language="dart"
                   code={`// Save password credentials
-await credentialManager.savePasswordCredential(
+await credentialManager.savePasswordCredentials(
   PasswordCredential(
     username: 'user@example.com',
     password: 'password123',
@@ -48,7 +48,7 @@ print('Password: \${credential.password}');`}
                 <CodeBlock
                   language="dart" 
                   code={`// Save password credentials (unchanged)
-await credentialManager.savePasswordCredential(
+await credentialManager.savePasswordCredentials(
   PasswordCredential(
     username: 'user@example.com',
     password: 'password123',

--- a/docSite/src/pages/UsagePage.tsx
+++ b/docSite/src/pages/UsagePage.tsx
@@ -78,7 +78,7 @@ if (!credentialManager.isGmsAvailable) {
       <CodeBlock
         language="dart"
         code={`try {
-  await credentialManager.savePasswordCredential(
+  await credentialManager.savePasswordCredentials(
     PasswordCredential(
       username: '1234567890',
       password: 'password',
@@ -546,10 +546,12 @@ print('Passkey Raw ID: \${credential.rawId}');`}
     ),
   );
   // Process result
-} catch (CredentialCancelledException e) {
-  print('User cancelled the operation');
-} catch (CredentialRequestException e) {
-  print('Credential request failed: \${e.message}');
+} on CredentialException catch (e) {
+  if (e.code == 201) {
+    print('User cancelled the operation');
+  } else {
+    print('Credential request failed (\${e.code}): \${e.message}');
+  }
 } catch (e) {
   print('Unexpected error: \${e}');
 }`}

--- a/docSite/tailwind.config.ts
+++ b/docSite/tailwind.config.ts
@@ -104,8 +104,15 @@ export default {
                 'pulse-soft': 'pulse-soft 3s infinite ease-in-out'
 			},
             fontFamily: {
-                sans: ['Inter', 'sans-serif'],
-                mono: ['JetBrains Mono', 'monospace'],
+                sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+                mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'monospace'],
+            },
+            boxShadow: {
+                'glow': '0 0 0 1px hsl(var(--primary) / 0.1), 0 8px 30px -8px hsl(var(--primary) / 0.35)',
+            },
+            backgroundImage: {
+                'grid-pattern':
+                    'linear-gradient(to right, hsl(var(--border) / 0.6) 1px, transparent 1px), linear-gradient(to bottom, hsl(var(--border) / 0.6) 1px, transparent 1px)',
             }
 		}
 	},


### PR DESCRIPTION
## Summary
- Fixes broken/stale code samples across the docs site (wrong method names, wrong field nesting, nonexistent exception types, fictional homepage API snippet) and backfills missing changelog entries.
- Fixes mobile navigation (backdrop, close-on-navigate, slide animation) which previously had no backdrop and stayed stuck open after tapping a link.
- Upgrades search to match page content (headings, API names, FAQ questions), not just page titles.
- Adds sidebar grouping + icons, breadcrumbs, mobile "On this page" panel, hover-to-copy heading anchors, reading time, back-to-top button.
- Fixes heading deep-links to be HashRouter-safe (previously a bare `#heading-id` fragment 404'd because it clobbered the route).
- Visual refresh: loads the Inter/JetBrains Mono fonts the Tailwind config already declared but never fetched, introduces a blue/violet brand accent, redesigns the homepage.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all changed/new files
- [x] `vite build` succeeds
- [ ] Manual check in a browser (mobile drawer, search, dark mode) — not verified visually, no browser tool available in the authoring environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added grouped documentation navigation with icons, breadcrumbs, reading-time estimates, and “Edit this page” links.
  * Added documentation search with grouped results and keyboard shortcut support.
  * Added mobile table of contents, heading links, and a back-to-top button.
  * Refreshed the homepage with updated feature highlights, code examples, branding, and visual styling.

* **Bug Fixes**
  * Corrected credential method names and passkey examples across the documentation.
  * Improved credential error-handling guidance and fixed an iOS setup instruction.

* **Documentation**
  * Added changelog entries for versions 3.0.0 and 3.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->