### PR TITLE
fix: address CodeRabbit findings from #76, gate CI on Dart changes, add expert skill

### DIFF
--- a/.claude/skills/credential-manager-expert/SKILL.md
+++ b/.claude/skills/credential-manager-expert/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: credential-manager-expert
+description: Expert on the flutter_credential_manager_compose plugin (pub.dev package "credential_manager") — Android Jetpack Credential Manager, iOS Keychain/AutoFill, passkeys (FIDO2/WebAuthn), password credentials, and Google Sign-In in Flutter. Use this skill whenever the user asks about implementing passkeys, biometric sign-in, password autofill, "one tap" or "one-tap" Google sign-in, Credential Manager errors/exception codes, Digital Asset Links / assetlinks.json, Associated Domains / apple-app-site-association, Swift Package Manager vs CocoaPods for this plugin, or when writing/reviewing/debugging any Dart code that imports credential_manager, credential_manager_platform_interface, credential_manager_android, or credential_manager_ios. Also use it for questions phrased generically like "how do I save a login in my Flutter app" or "how do I let iOS/Android suggest a password" — those almost always mean this plugin's password-credential or passkey flow. Trigger even if the user doesn't name the package explicitly, as long as they're working in this repo or clearly building on this plugin.
+---
+
+# Credential Manager Expert
+
+You are acting as the resident expert on `flutter_credential_manager_compose`, a federated Flutter
+plugin that wraps Android's Jetpack Credential Manager and iOS Keychain/AutoFill behind one Dart
+API. Your job is to write, review, and debug code against the *actual* current API — not the
+plausible-sounding API an LLM might guess at. This plugin has a real history of docs drifting from
+code (wrong method names, wrong field nesting, invented exception classes), so treat every claim in
+this file as ground truth extracted directly from source, and re-verify against source if the code
+in this repo has moved on since.
+
+## Package layout
+
+```
+credential_manager_platform_interface   (Dart contracts: models, exceptions, CredentialManagerPlatform)
+        ^                    ^
+credential_manager_android   credential_manager_ios      (native Kotlin / Swift implementations)
+        ^                            ^
+              credential_manager     (umbrella package — this is what apps actually import)
+```
+
+Always `import 'package:credential_manager/credential_manager.dart';` in application code — it
+re-exports everything from the platform interface (models, exceptions, `CredentialManager`).
+
+## The core API, exactly as it exists today
+
+`CredentialManager` (from `credential_manager_core.dart`) is an **instance-based** class — not
+static methods. This has been a recurring source of hallucination; there is no
+`CredentialManager.save(...)` static API. Always construct one:
+
+```dart
+final credentialManager = CredentialManager();
+
+if (credentialManager.isSupportedPlatform) {   // Platform.isAndroid || Platform.isIOS
+  await credentialManager.init(
+    preferImmediatelyAvailableCredentials: true,  // required named param
+    googleClientId: '<your-web-client-id>',       // optional, only needed for Google Sign-In
+  );
+}
+
+if (!credentialManager.isGmsAvailable) {
+  // Android-only signal (always true on iOS). False means Google Play Services is missing —
+  // don't launch Google flows, you'll otherwise hit exception code 209.
+}
+```
+
+Full method surface (get the exact signature right — these are commonly mis-typed):
+
+| Method | Signature | Notes |
+|---|---|---|
+| `savePasswordCredentials` | `Future<void> savePasswordCredentials(PasswordCredential credential)` | **Plural** "Credentials". `savePasswordCredential` (singular) does not exist — this exact typo has shipped in the docs before. |
+| `savePasskeyCredentials` | `Future<PublicKeyCredential> savePasskeyCredentials({required CredentialCreationOptions request})` | Registers/creates a passkey. |
+| `getCredentials` | `Future<Credentials> getCredentials({CredentialLoginOptions? passKeyOption, FetchOptionsAndroid? fetchOptions})` | One entry point for reading back password, passkey, or Google credentials. |
+| `saveGoogleCredential` | `Future<GoogleIdTokenCredential?> saveGoogleCredential({bool useButtonFlow = false})` | Android-only in practice. |
+| `logout` | `Future<void> logout()` | Android-only effect (clears session); no-op on iOS. |
+| `getPlatformVersion` | `Future<String?> getPlatformVersion()` | Diagnostic only. |
+
+Getters: `isSupportedPlatform` (bool), `isGmsAvailable` (bool, set during `init`).
+
+## Models — get the field nesting right
+
+This is the single most common mistake when generating code against this plugin. `PublicKeyCredential`
+has some fields directly on it and others nested one level down in `.response`. Don't guess — use
+this table:
+
+**`PasswordCredential`**: `username`, `password` (both `String?`, mutable getters/setters).
+
+**`PublicKeyCredential`** (top level): `id`, `rawId`, `type`, `authenticatorAttachment`,
+`transports` (`List<String>?`), `clientExtensionResults`, `publicKeyAlgorithm` (`int?`),
+`publicKey` (`String?`), and `response` (a nested `Response` object).
+
+**`PublicKeyCredential.response`** (nested `Response` class): `clientDataJSON`, `attestationObject`,
+`authenticatorData`, `publicKey`, `transports`, `signature`, `userHandle`.
+
+So: `credential.publicKeyAlgorithm` — NOT `credential.response.publicKeyAlgorithm`. But
+`credential.response.clientDataJSON` — NOT `credential.clientDataJSON`. When in doubt, check
+`references/api-reference.md` for the full field list rather than inferring from WebAuthn spec
+naming conventions, because this plugin's shape doesn't perfectly mirror the browser
+`PublicKeyCredential` JS object.
+
+**`Credentials`** (the return type of `getCredentials`): a bag with three optional fields —
+`passwordCredential`, `publicKeyCredential`, `googleIdTokenCredential` — exactly one of which is
+populated depending on what was fetched/found. Always null-check before use; on Android a "not
+found" result comes back as an empty `Credentials` object rather than throwing.
+
+**`GoogleIdTokenCredential`**: `email`, `idToken` (required), plus optional `displayName`,
+`familyName`, `givenName`, `phoneNumber`, `profilePictureUri`.
+
+**`FetchOptionsAndroid`**: `passKey`, `googleCredential`, `passwordCredential` (all default `false`
+in the constructor — pass the ones you want `true`). Android-specific; harmless but unused on iOS.
+
+**`CredentialLoginOptions`** (for reading a passkey): `challenge` and `rpId` required,
+`userVerification` required, `timeout` (default 1800000ms/30min), `conditionalUI` (iOS-only,
+default `false` — shows the passkey hint on the keyboard when `true`).
+
+**`CredentialCreationOptions`** (for creating a passkey): `challenge`, `rp` (`Rp(name, id)`),
+`user` (`User(id, name, displayName)`), `pubKeyCredParams`, `excludeCredentials`,
+`authenticatorSelection`, `timeout` (default 1800000), `attestation` (default `'none'`). Usually
+built with `CredentialCreationOptions.fromJson(map)` from a server-issued challenge — see
+`references/api-reference.md` for the full JSON shape including Android-only fields
+(`pubKeyCredParams`, `authenticatorSelection` needs `residentKey: "required"` on Android).
+
+## Exceptions
+
+Only one exception type exists: `CredentialException implements Exception`, with `code` (int),
+`message` (String), `details` (dynamic). There is no `CredentialCancelledException`,
+`CredentialRequestException`, or similar — do not invent subclasses.
+
+```dart
+try {
+  await credentialManager.savePasswordCredentials(PasswordCredential(username: u, password: p));
+} on CredentialException catch (e) {
+  if (e.code == 201) {
+    // user cancelled — expected, don't show an error toast
+  } else {
+    // real failure — see references/troubleshooting.md for the full code table
+  }
+}
+```
+
+Codes worth knowing without opening the reference: **201** = user cancelled (all flows), **202** =
+no credentials found, **207** = no Google account on device (plugin auto-opens account settings),
+**209** = Google Play Services unavailable, **601–603** = passkey-specific failures. Full table with
+every code and when it fires: `references/troubleshooting.md`.
+
+## Platform support matrix
+
+- **Passwords**: Android (Credential Manager) + iOS (Keychain/AutoFill via `AutofillGroup` +
+  `autofillHints`). Both platforms.
+- **Passkeys**: Android 14+ and iOS 16+ only. Older OS versions throw — always gate passkey UI
+  behind a version/capability check rather than assuming availability.
+- **Google Sign-In**: Android only in practice (`saveGoogleCredential`/`googleCredential` fetch
+  option). Don't wire it into an iOS-only code path.
+- **`logout()`**: clears Android session state; no meaningful effect on iOS.
+
+## When you need native setup details
+
+Don't try to reconstruct Android manifest/proguard rules or iOS entitlements from memory — read the
+relevant reference file, because these involve exact JSON/XML shapes that are easy to get subtly
+wrong (wrong relation strings in `assetlinks.json`, wrong Associated Domains prefix, etc.):
+
+- **Android native setup** (proguard, Digital Asset Links / `assetlinks.json`, Google Cloud Console
+  OAuth client, SHA-1 fingerprints): `references/android-setup.md`
+- **iOS native setup** (Associated Domains, `apple-app-site-association`, Keychain Sharing
+  capability, SPM vs CocoaPods): `references/ios-setup.md`
+- **Full API reference** (every class/method/field, JSON shapes for passkey creation options):
+  `references/api-reference.md`
+- **Exception code table + common failure scenarios and fixes**: `references/troubleshooting.md`
+
+## Versioning convention (if asked to bump versions)
+
+This repo does **not** use standard semver bump rules. Bug fix or small change → **minor** bump.
+Migration, new feature, or breaking change → **major** bump. This is intentional and documented in
+the repo's own `CLAUDE.md` — follow it as-is, don't "correct" it to standard semver.
+
+## A note on trust
+
+This plugin's own documentation site has shipped incorrect method names, wrong field nesting, and
+fictional exception types before — all traced back to LLM-plausible-sounding code that was never
+checked against source. When writing example code for this plugin, prefer copying patterns from
+this file (which was built by reading the actual `.dart` source) over generating from general
+WebAuthn/Credential-Manager knowledge, since this plugin's Dart surface has its own specific shape
+that doesn't map 1:1 onto the underlying platform APIs or the browser WebAuthn spec.

--- a/.claude/skills/credential-manager-expert/references/android-setup.md
+++ b/.claude/skills/credential-manager-expert/references/android-setup.md
@@ -1,0 +1,123 @@
+# Android Native Setup
+
+Ground truth from `docSite/src/pages/ConfigurationPage.tsx` and `UsagePage.tsx`, cross-checked
+against the plugin's actual Android requirements. These are exact file contents/paths, not
+paraphrases — copy them rather than reconstructing from memory of "how Credential Manager usually
+works," since small mistakes here (wrong relation string, wrong file path) cause silent failures.
+
+## 1. Proguard rules
+
+Needed because release builds with R8/Proguard strip the Credential Manager / Play Services
+integration classes unless told not to. Create or update `android/app/proguard-rules.pro`:
+
+```
+-if class androidx.credentials.CredentialManager
+-keep class androidx.credentials.playservices.** {
+  *;
+}
+```
+
+And enable minification with those rules in `android/app/build.gradle`:
+
+```kotlin
+android {
+  buildTypes {
+    release {
+      minifyEnabled true
+      proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+    }
+  }
+}
+```
+
+## 2. Digital Asset Links (`assetlinks.json`)
+
+Required for **both** passkeys and Google-backed password autofill suggestions on Android — it's
+how Android verifies your app is allowed to act on behalf of your web domain. Without this, the
+Credential Manager UI won't offer to save/autofill for your app.
+
+Create `assetlinks.json`:
+
+```json
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls",
+      "delegate_permission/common.get_login_creds"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "your.package.name",
+      "sha256_cert_fingerprints": [
+        "YOUR_APP_SIGNATURE_SHA256_HASH"
+      ]
+    }
+  }
+]
+```
+
+Both `relation` entries matter: `handle_all_urls` is the standard App Links verification, but
+`get_login_creds` is the one that specifically authorizes credential save/autofill — don't drop it
+even if you already have App Links set up for other reasons.
+
+Host it at: `https://yourdomain.com/.well-known/assetlinks.json`
+
+If you have a `robots.txt`, make sure it doesn't block Google's crawler from fetching that path:
+
+```
+User-agent: *
+Allow: /.well-known/
+```
+
+### Getting the SHA-256 (or SHA-1, for OAuth) fingerprint
+
+```bash
+cd android && ./gradlew signingReport
+```
+
+or
+
+```bash
+keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android
+```
+
+Remember debug and release keystores have *different* fingerprints — you need the release one
+registered for production, and typically both registered while developing (debug for local testing,
+release for the actual release build/Play Store signing).
+
+## 3. Google Sign-In / OAuth client setup
+
+Google Sign-In on this plugin (`saveGoogleCredential`, or `getCredentials(fetchOptions:
+FetchOptionsAndroid(googleCredential: true))`) needs an OAuth client configured in Google Cloud
+Console — and specifically needs a **Web application** OAuth client ID (not the Android one) passed
+as `googleClientId` to `CredentialManager.init`. This trips people up: you still register an Android
+OAuth client (tied to your SHA-1 + package name, so Google trusts the calling app), but the ID you
+actually pass into the Dart code is the *Web* client's ID.
+
+Steps:
+1. Go to [Google Cloud Console](https://console.cloud.google.com/), create/select a project.
+2. APIs & Services → OAuth consent screen → configure it (choose External or Internal user type).
+3. APIs & Services → Credentials → Create Credentials → OAuth client ID.
+4. Application type **Android**: enter your package name and the SHA-1 fingerprint (see above).
+   This authorizes the calling app but you don't use this client ID directly in code.
+5. Create a **second** OAuth client ID, application type **Web application**. Authorized JS
+   origins/redirect URIs can be left blank for this plugin's use case.
+6. Copy the **Web** client's Client ID and pass it to `init`:
+
+```dart
+await credentialManager.init(
+  preferImmediatelyAvailableCredentials: true,
+  googleClientId: '<the-web-application-client-id>',
+);
+```
+
+## 4. Passkeys on Android — platform requirements
+
+Passkeys require **Android 14+**. Digital Asset Links setup (step 2 above) is a hard prerequisite —
+without it, passkey creation/retrieval will fail even with correct Dart code. There is no separate
+Android manifest permission needed beyond what Credential Manager / Play Services already requires
+via the dependency.
+
+When building `CredentialCreationOptions` for Android, the `authenticatorSelection.residentKey`
+field needs to be `"required"` — Android's implementation expects a discoverable/resident credential
+for its passkey flow. See `api-reference.md` for the full JSON shape.

--- a/.claude/skills/credential-manager-expert/references/api-reference.md
+++ b/.claude/skills/credential-manager-expert/references/api-reference.md
@@ -1,0 +1,218 @@
+# API Reference
+
+Ground truth extracted from:
+- `packages/credential_manager/lib/src/credential_manager_core.dart`
+- `packages/credential_manager_platform_interface/lib/src/**`
+
+If the code has moved on since this was written, re-read those files rather than trusting this
+verbatim — but as of the plugin versions in this repo's `CLAUDE.md` (platform_interface 2.0.8,
+android/ios/credential_manager 3.0.1), this is exact.
+
+## `CredentialManager`
+
+Instantiate directly — the constructor registers the right platform plugin for you:
+
+```dart
+final credentialManager = CredentialManager();
+```
+
+| Member | Signature |
+|---|---|
+| `isSupportedPlatform` | `bool` getter — `Platform.isAndroid \|\| Platform.isIOS` |
+| `isGmsAvailable` | `bool` getter — Android Play Services availability, always `true` on iOS, set during `init` |
+| `getPlatformVersion()` | `Future<String?>` |
+| `init(...)` | `Future<void> init({required bool preferImmediatelyAvailableCredentials, String? googleClientId})` |
+| `savePasswordCredentials(credential)` | `Future<void> savePasswordCredentials(PasswordCredential credential)` |
+| `savePasskeyCredentials(...)` | `Future<PublicKeyCredential> savePasskeyCredentials({required CredentialCreationOptions request})` |
+| `getCredentials(...)` | `Future<Credentials> getCredentials({CredentialLoginOptions? passKeyOption, FetchOptionsAndroid? fetchOptions})` |
+| `saveGoogleCredential(...)` | `Future<GoogleIdTokenCredential?> saveGoogleCredential({bool useButtonFlow = false})` |
+| `logout()` | `Future<void> logout()` |
+
+`preferImmediatelyAvailableCredentials`: when `true`, tells the authorization controller to prefer
+credentials already available on-device rather than round-tripping to platform native flows.
+Defaults to `false` when omitted (note the constructor makes it a *required* named param on
+`CredentialManager.init`, even though the underlying platform interface treats it as a plain bool).
+
+`useButtonFlow`: `true` = classic "Sign in with Google" button/alert-dialog flow. `false` = the
+newer Credential Manager one-tap UI.
+
+## Models
+
+### `PasswordCredential`
+```dart
+class PasswordCredential {
+  PasswordCredential({String? username, String? password});
+  String? username;   // mutable getter/setter
+  String? password;   // mutable getter/setter
+}
+```
+
+### `Credentials` (return type of `getCredentials`)
+```dart
+class Credentials {
+  final PasswordCredential? passwordCredential;
+  final GoogleIdTokenCredential? googleIdTokenCredential;
+  final PublicKeyCredential? publicKeyCredential;
+}
+```
+Exactly one is populated per call, depending on `fetchOptions`/what was found. On Android, "not
+found" returns an empty `Credentials` (all null) rather than throwing `CredentialException`.
+
+### `GoogleIdTokenCredential`
+```dart
+class GoogleIdTokenCredential {
+  final String email;          // required
+  final String idToken;        // required
+  final String? displayName;
+  final String? familyName;
+  final String? givenName;
+  final String? phoneNumber;
+  final Uri? profilePictureUri;
+}
+```
+
+### `FetchOptionsAndroid`
+```dart
+FetchOptionsAndroid({
+  bool passKey = false,
+  bool googleCredential = false,
+  bool passwordCredential = false,
+});
+// FetchOptionsAndroid.all() sets all three true
+```
+Android-specific fetch filter, passed to `getCredentials(fetchOptions: ...)`. On iOS this parameter
+is effectively ignored — iOS auto-detects what to fetch from context (e.g. `AutofillGroup` for
+passwords, `conditionalUI` for passkeys).
+
+### `CredentialLoginOptions` (reading a passkey via `getCredentials(passKeyOption: ...)`)
+```dart
+CredentialLoginOptions({
+  required String challenge,
+  required String rpId,
+  required String userVerification,
+  int timeout = 1800000,        // 30 minutes, ms
+  bool conditionalUI = false,   // iOS-only: shows passkey hint on keyboard when true
+});
+```
+Required on **both platforms** if you want passkey credentials back — omitting it when you actually
+want a passkey throws. It's fine to omit when you only want password/Google credentials.
+
+### `CredentialCreationOptions` (creating a passkey via `savePasskeyCredentials`)
+```dart
+CredentialCreationOptions({
+  required String challenge,
+  required Rp rp,                                       // Rp(name, id)
+  required User user,                                    // User(id, name, displayName)
+  required List<PublicKeyCredentialParameters> pubKeyCredParams,
+  int timeout = 1800000,
+  String attestation = 'none',
+  required List<ExcludeCredential> excludeCredentials,   // can be []
+  required AuthenticatorSelectionCriteria authenticatorSelection,
+});
+```
+Typically constructed via `CredentialCreationOptions.fromJson(map)` from a server-issued challenge
+payload. Example JSON shape (this is what a typical WebAuthn-style backend returns, with Android
+requiring a couple of extra platform-specific fields):
+
+```dart
+final credentialCreationOptions = {
+  "challenge": "<base64url-encoded challenge from your server>",
+  "rp": {"name": "My App", "id": rpId},           // rpId = your domain, e.g. "example.com"
+  "user": {
+    "id": encodedUserId,      // base64url-encoded, stable per-user identifier
+    "name": username,
+    "displayName": username,
+  },
+  "excludeCredentials": [],   // existing credential IDs to exclude, or []
+};
+
+if (Platform.isAndroid) {
+  credentialCreationOptions.addAll({
+    "pubKeyCredParams": [
+      {"type": "public-key", "alg": -7},    // ES256
+      {"type": "public-key", "alg": -257},  // RS256
+    ],
+    "timeout": 1800000,
+    "attestation": "none",
+    "authenticatorSelection": {
+      "authenticatorAttachment": "platform",
+      "residentKey": "required",       // required on Android
+      "userVerification": "required",
+    },
+  });
+}
+
+final credential = await credentialManager.savePasskeyCredentials(
+  request: CredentialCreationOptions.fromJson(credentialCreationOptions),
+);
+```
+
+`Rp`: `{name, id}`. `User`: `{id, name, displayName}`. `PublicKeyCredentialParameters`:
+`{type, alg}` (COSE algorithm identifiers — `-7` = ES256, `-257` = RS256).
+`AuthenticatorSelectionCriteria`: `{authenticatorAttachment?, requireResidentKey?, residentKey?,
+userVerification?}` — all optional but Android needs `residentKey: "required"` in practice.
+`ExcludeCredential`: `{id, type}`.
+
+### `PublicKeyCredential` (return type of `savePasskeyCredentials`, and
+`Credentials.publicKeyCredential`)
+
+```dart
+class PublicKeyCredential {
+  String? rawId;
+  String? authenticatorAttachment;
+  String? type;                          // defaults to 'public-key'
+  String? id;
+  Response? response;                    // nested — see below
+  List<String>? transports;
+  ClientExtensionResults? clientExtensionResults;
+  int? publicKeyAlgorithm;               // TOP LEVEL, not under .response
+  String? publicKey;                     // TOP LEVEL, not under .response
+}
+```
+
+### `Response` (nested under `PublicKeyCredential.response`)
+```dart
+class Response {
+  String? clientDataJSON;      // NESTED here, not on PublicKeyCredential directly
+  String? attestationObject;
+  String? authenticatorData;
+  String? publicKey;           // note: Response also has its own publicKey field
+  List<String>? transports;
+  String? signature;
+  String? userHandle;
+}
+```
+
+Common mapping mistake to avoid when building a registration/assertion payload to send to a server:
+
+```dart
+final registrationResponse = {
+  "id": credential.id,
+  "rawId": credential.rawId,
+  "type": credential.type,
+  "clientDataJSON": credential.response?.clientDataJSON,   // nested under response
+  "attestationObject": credential.response?.attestationObject,
+  "authenticatorData": credential.response?.authenticatorData,
+  "publicKey": credential.publicKey,                        // top-level on credential
+  "publicKeyAlgorithm": credential.publicKeyAlgorithm,       // top-level on credential
+  "transports": credential.transports,                       // top-level on credential
+};
+```
+
+### `ClientExtensionResults` / `CredProps`
+```dart
+class ClientExtensionResults { CredProps? credProps; }
+class CredProps { bool? rk; }   // whether the credential is a resident/discoverable key
+```
+
+## `CredentialException`
+
+```dart
+class CredentialException implements Exception {
+  final int code;
+  final String message;
+  final dynamic details;
+}
+```
+
+The only exception type this plugin throws. See `troubleshooting.md` for the full code table.

--- a/.claude/skills/credential-manager-expert/references/ios-setup.md
+++ b/.claude/skills/credential-manager-expert/references/ios-setup.md
@@ -1,0 +1,125 @@
+# iOS Native Setup
+
+Ground truth from `docSite/src/pages/ConfigurationPage.tsx`. iOS uses **Keychain** for passkeys and
+**AutoFill** (backed by Keychain) for password credentials — there's no separate SDK to install
+beyond this plugin; the work is entitlements + hosting a verification file.
+
+## 1. Swift Package Manager vs CocoaPods
+
+Since `credential_manager_ios` v3.0.0, the package ships **both** a `Package.swift` (SPM) and the
+original `credential_manager_ios.podspec` (CocoaPods) from the same `Sources/` directory — you don't
+need to choose per-plugin, Flutter picks based on your app's setup. No breaking changes to the Dart
+API either way.
+
+Why this matters: Flutter defaults to SPM from 3.24+, and CocoaPods' trunk registry goes read-only
+December 2, 2026 — after that, new plugin *versions* can only be published via SPM. Migrating ahead
+of time is recommended but not urgent for existing CocoaPods setups.
+
+**Enabling SPM** (if not already your Flutter channel's default):
+```bash
+flutter config --enable-swift-package-manager
+```
+Then just `flutter pub get` && `flutter run`/`flutter build ios` — Flutter auto-detects the
+`Package.swift` and integrates it as a Swift Package. If your `ios/Podfile` still has other
+CocoaPods-only dependencies, Flutter keeps using CocoaPods for those while resolving SPM-compatible
+plugins (like this one) through SPM — you don't have to migrate the whole project at once.
+
+**Migrating an existing CocoaPods-only project to SPM fully** (only once every plugin you depend on
+supports SPM):
+```bash
+cd ios
+pod deintegrate
+```
+Then delete `Podfile`/`Podfile.lock` if you have no remaining CocoaPods-only deps, and re-run
+`flutter build ios` to regenerate the Xcode project against SPM.
+
+See Flutter's official [Swift Package Manager for app developers](https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers) guide for the general (non-plugin-specific) parts of this migration.
+
+## 2. Enabling Password AutoFill
+
+1. Open the project in Xcode.
+2. App target → **Signing & Capabilities** tab.
+3. Click "+" → add **Associated Domains** capability.
+4. Add both prefixes for your domain:
+   - `applinks:yourdomain.com`
+   - `webcredentials:yourdomain.com`
+
+   Both are needed — `webcredentials:` is what actually authorizes AutoFill/Keychain to associate
+   credentials with your domain; `applinks:` is separate (universal links) but commonly needed
+   alongside it if you also deep-link from that domain.
+
+5. Host an `apple-app-site-association` file (no file extension, served as
+   `application/json` or `application/pkcs7-mime`, no redirects) at your domain root:
+
+```json
+{
+  "applinks": {
+    "apps": [],
+    "details": [{
+      "appIDs": ["<team_id>.com.yourappname"]
+    }]
+  },
+  "webcredentials": {
+    "apps": [
+      "<team_id>.com.yourappname"
+    ]
+  }
+}
+```
+
+   Must be reachable at `https://yourdomain.com/.well-known/apple-app-site-association` (no
+   `.well-known` fallback needed at root, but `.well-known` is the modern/preferred location — serve
+   it at both if unsure). `<team_id>` is your Apple Developer Team ID; `com.yourappname` is your
+   app's bundle identifier — concatenated as `TEAMID.bundle.id`, no separator.
+
+6. Validate:
+```bash
+curl -X GET https://yourdomain.com/.well-known/apple-app-site-association
+```
+   Or use the [Branch AASA Validator](https://branch.io/resources/aasa-validator/). Common failure:
+   serving it with a redirect or wrong content-type — Apple's fetcher won't follow redirects for
+   this file.
+
+7. In the Flutter widget tree, wrap username/password fields in `AutofillGroup` with the right
+   `autofillHints` so iOS knows what to save/suggest:
+
+```dart
+AutofillGroup(
+  child: Column(
+    children: [
+      TextFormField(
+        autofillHints: const [AutofillHints.username],
+        decoration: const InputDecoration(labelText: 'Username'),
+      ),
+      TextFormField(
+        autofillHints: const [AutofillHints.password],
+        decoration: const InputDecoration(labelText: 'Password'),
+        obscureText: true,
+      ),
+    ],
+  ),
+);
+```
+   After validating the form and completing the sign-in action, iOS's native AutoFill save-password
+   prompt appears automatically — there's no explicit Dart call needed to trigger the iOS save UI
+   (contrast with Android, where you explicitly call `savePasswordCredentials`). On retrieval, the
+   Keychain access prompt appears on the keyboard as soon as the user focuses the field.
+
+## 3. Keychain Sharing (needed for passkeys, and for sharing credentials across apps in the same team)
+
+1. Add the **Keychain Sharing** capability in Signing & Capabilities.
+2. Enter a keychain group name — this needs to match across every app/extension in your team that
+   should share access to the same stored credentials.
+
+## 4. Passkeys on iOS — platform requirements
+
+Passkeys require **iOS 16+**. Unlike Android, there's no extra native config beyond what's already
+required for AutoFill (the Associated Domains + `apple-app-site-association` setup above) — the
+`webcredentials` entry in that JSON file is what iOS uses for passkey RP-ID verification too, not
+just password AutoFill. If AutoFill already works, passkeys typically need zero additional native
+setup, just the correct `CredentialCreationOptions`/`CredentialLoginOptions` on the Dart side (see
+`api-reference.md`).
+
+`CredentialLoginOptions.conditionalUI: true` is iOS-specific — set it when you want the passkey
+hint to appear as a suggestion above the keyboard (WebAuthn "conditional mediation") rather than a
+full modal prompt.

--- a/.claude/skills/credential-manager-expert/references/troubleshooting.md
+++ b/.claude/skills/credential-manager-expert/references/troubleshooting.md
@@ -1,0 +1,79 @@
+# Troubleshooting & Exception Codes
+
+Ground truth from `packages/credential_manager_platform_interface/lib/src/utils/platform_exception_handler.dart`
+and `.../src/exceptions/exceptions.dart`. Every code below is a real, currently-thrown
+`CredentialException.code` value — this is the mapping the plugin itself uses internally, not a
+guess.
+
+## Full code table
+
+| Code | Message | When it fires / what to do |
+|---|---|---|
+| 101 | Initialization failure | `init()` failed at the platform layer. Check native setup (see `android-setup.md` / `ios-setup.md`). |
+| 102 | Plugin exception | Generic platform-channel error; inspect `details`. |
+| 103 | Not implemented | Called a method the current platform doesn't support (e.g. passkeys on an unsupported OS version). |
+| 201 | Login cancelled (or "Login with Google cancelled" for Google flows) | User dismissed the system UI. **Not an error** — handle silently, don't show a toast. |
+| 202 | No credentials found | Fetch returned nothing. Android instead often returns an empty `Credentials` object rather than throwing this — check both paths. |
+| 203 | Mismatched credentials | The stored credential doesn't match what was requested (e.g. RP ID mismatch). |
+| 204 | Login failed | Generic failure during credential retrieval. |
+| 205 | Temporarily blocked | Too many cancelled sign-in prompts in a row; also raised on iOS when the underlying error contains `[28436]`. Back off and let the user retry later — don't immediately re-prompt. |
+| 206 | Credential fetch options not enabled | You called `getCredentials` without the right `fetchOptions` flags set for what you're trying to retrieve. |
+| 207 | No Google account present | Android found no signed-in Google account. **The plugin automatically opens the "Add account" settings screen** — don't duplicate that by also showing your own account-picker. |
+| 208 | RequestJson is required for passkey | You need a `passKeyOption` (for reads) or a properly-built `request` (for creates) — one was missing/malformed. |
+| 209 | Google Play Services not available | Check `credentialManager.isGmsAvailable` *before* attempting Google flows to avoid ever hitting this. |
+| 301 | Save Credentials cancelled (or "Save Google Credentials cancelled") | User dismissed the save prompt. Not an error. |
+| 302 | Create Credentials failed | Generic failure while saving. |
+| 401 | Encryption failed | Internal storage failure. |
+| 402 | Decryption failed | Internal storage failure, often means corrupted/tampered stored data. |
+| 501 | Received an invalid Google ID token response | Malformed response from Google — check `googleClientId` is the **Web** OAuth client ID, not the Android one (common cause). |
+| 502 | Invalid request | Malformed request sent to the platform layer. |
+| 503 | Google client is not initialized yet | Called a Google-related method before `init()` completed, or `init()` was called without `googleClientId`. |
+| 504 | Credentials operation failed | Also the fallback/default code for any unmapped native error — check `details` for the real underlying message. |
+| 505 | Google credential decode error | Failed to parse the Google ID token response. |
+| 601 | User cancelled passkey operation | Not an error — same idea as 201/301 but passkey-specific. |
+| 602 | Passkey creation failed | Failure during `savePasskeyCredentials`. Check Digital Asset Links (Android) / Associated Domains (iOS) setup first — this is the most common root cause. |
+| 603 | Passkey failed to fetch | Failure during `getCredentials(passKeyOption: ...)`. Same setup issues as 602 are the usual culprit. |
+
+## Recommended error-handling pattern
+
+Treat "cancelled" codes (201, 301, 601) as normal user behavior, not failures:
+
+```dart
+try {
+  await credentialManager.savePasswordCredentials(
+    PasswordCredential(username: username, password: password),
+  );
+} on CredentialException catch (e) {
+  switch (e.code) {
+    case 201:
+    case 301:
+      // user cancelled — no error UI needed
+      break;
+    case 209:
+      // Play Services unavailable — you should have checked isGmsAvailable earlier
+      break;
+    default:
+      // real failure — surface e.message / e.code to the user or your error tracker
+  }
+}
+```
+
+There is only ever one exception type — `CredentialException` — never write `catch
+(CredentialCancelledException e)` or similar; that class does not exist and code written against
+it will fail to compile.
+
+## Common root causes, by symptom
+
+- **"Passkey creation/fetch always fails, no matter what I pass"** → almost always a Digital Asset
+  Links (Android) or Associated Domains / `apple-app-site-association` (iOS) setup problem, not a
+  Dart bug. Validate the hosted files directly (`curl`, Branch AASA validator) before debugging Dart
+  code further.
+- **"Google Sign-In throws 501/503"** → wrong client ID type. `googleClientId` passed to `init()`
+  must be the **Web application** OAuth client, not the Android one.
+- **"Nothing happens when I focus the password field on iOS"** → the field is missing
+  `autofillHints`, or it's not inside an `AutofillGroup`, or Associated Domains/AASA isn't set up.
+- **"Works on Android, nothing on iOS" for Google Sign-In** → expected. `saveGoogleCredential` /
+  `FetchOptionsAndroid(googleCredential: true)` are Android-only in practice.
+- **"getCredentials returns nothing but doesn't throw"** → check on Android specifically: an empty
+  `Credentials` (all fields null) is a valid non-error "nothing found" result, distinct from a
+  thrown 202. Always null-check the result even inside a successful `try` block.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     name: Detect changed paths
     runs-on: ubuntu-latest
     outputs:
+      dart: ${{ steps.filter.outputs.dart }}
       android: ${{ steps.filter.outputs.android }}
       ios: ${{ steps.filter.outputs.ios }}
     steps:
@@ -17,6 +18,12 @@ jobs:
         id: filter
         with:
           filters: |
+            dart:
+              - 'packages/**/*.dart'
+              - 'packages/**/pubspec.yaml'
+              - 'packages/**/analysis_options.yaml'
+              - 'pubspec.yaml'
+              - '.github/workflows/ci.yml'
             android:
               - 'packages/credential_manager_android/**'
               - 'packages/credential_manager_platform_interface/**'
@@ -30,6 +37,8 @@ jobs:
 
   format:
     name: Dart format (120 cols)
+    needs: changes
+    if: needs.changes.outputs.dart == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +55,8 @@ jobs:
 
   analyze:
     name: Flutter analyze
+    needs: changes
+    if: needs.changes.outputs.dart == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,108 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repo.
+
+## What this is
+
+`flutter_credential_manager_compose` — a federated Flutter plugin exposing Android's Jetpack
+Credential Manager (one-tap sign-in, passkeys) and iOS Keychain/Autofill behind one Dart API.
+
+Packages (`packages/<name>`, melos-managed native Dart pub workspace, root `pubspec.yaml`):
+
+```
+credential_manager_platform_interface   (no internal deps)          v2.0.8
+        ^                    ^
+credential_manager_android   credential_manager_ios                 v3.0.1
+        ^                            ^
+              credential_manager (umbrella, + /example app)         v3.0.1
+```
+
+- `credential_manager_ios` ships **both** CocoaPods (`ios/credential_manager_ios.podspec`) and
+  Swift Package Manager (`ios/credential_manager_ios/Package.swift`) — same `Sources/` directory,
+  single source of truth. SPM is Flutter's default from 3.24+; CocoaPods stays supported.
+- Docs site lives in `docSite/` (Vite/React), deployed to
+  https://djsmk123.github.io/flutter_credential_manager_compose/ — includes an
+  iOS Configuration page section on enabling/migrating to SPM.
+
+## Repo tooling
+
+- **Melos** (`^8.1.0`) — config lives in root `pubspec.yaml`'s `melos:` key (melos 8 dropped
+  standalone `melos.yaml`); package list comes from the native `workspace:` field. Each member
+  package has `resolution: workspace` and `sdk: '>=3.5.0 <4.0.0'`.
+- **Makefile** (root) wraps melos + native linters so local dev, pre-commit, and CI run the
+  exact same commands:
+  - `make bootstrap` — activate melos + `melos bootstrap`
+  - `make format` / `make format-check` — `dart format --line-length 120 --page-width 120`
+    (fix vs. `--set-exit-if-changed`)
+  - `make analyze` — `flutter analyze` across every package
+  - `make lint-ios` — SwiftLint (`--strict`) on `credential_manager_ios`
+  - `make lint-android` — Detekt on `credential_manager_android`
+  - `make lint` — both native linters
+  - `make check` — `format-check` + `analyze` + `lint`, the full CI-equivalent gate
+- **Pre-commit** (`.pre-commit-config.yaml`) runs `make format` and `make analyze` on Dart files
+  (excludes `docSite/`).
+- **Line length is 120 columns everywhere** (Dart `formatter: page_width: 120` in each package's
+  `analysis_options.yaml`, SwiftLint `line_length`, Detekt `formatter.MaximumLineLength`) — not
+  Dart's 80-column default. Note: `dart format` only produces the "tall style" (matching this
+  codebase) once the package's language version resolves via `pub get`/`melos bootstrap` —
+  running it on an unbootstrapped checkout silently falls back to old short-style output
+  regardless of width flags. Always bootstrap first.
+- **Lint configs** (`packages/credential_manager_ios/.swiftlint.yml`,
+  `packages/credential_manager_android/android/detekt.yml`) are held at zero violations.
+  A few rules are deliberately relaxed with a documented reason inline (legacy package naming
+  with an underscore; generic exception catching at the Flutter method-channel boundary) —
+  don't "fix" those without cause, and don't add new suppressions without the same kind of
+  documented justification.
+
+## CI (`.github/workflows/ci.yml`)
+
+Runs on PRs into `main` or `develop`: `format` / `analyze` / `android-build` / `android-lint` /
+`ios-build` / `ios-lint`, all gated by a `dorny/paths-filter@v3` `changes` job so each job only
+runs when a PR actually touches its relevant paths — `format`/`analyze` need `dart` (any `.dart`
+file, package `pubspec.yaml`/`analysis_options.yaml`, root `pubspec.yaml`, or the workflow file
+itself); `android-build`/`android-lint` need `android`; `ios-build`/`ios-lint` need `ios`
+(`packages/credential_manager_android/**` + shared deps for android; analogous for ios). A
+docs-only PR (`docSite/**`) now skips every Dart/native job.
+
+## Branching & releases
+
+- Flow is `main → develop → feature branches`. Feature/release branches cut from `develop`,
+  PR'd back to `develop`; `develop` is later promoted to `main` via its own PR. Publishing to
+  pub.dev happens from `main`.
+- GitHub has "automatically delete head branches" enabled, so `develop` gets deleted every time
+  it's a merged PR's head (e.g. after a `develop → main` promotion). Recreate with
+  `git push origin main:develop`.
+- `main` has branch protection requiring 1 approving review — the agent cannot merge PRs into
+  it itself; a human must merge (or explicitly request `--admin`, which should not be assumed).
+- Version bump convention is **this repo's own, not standard semver**: bug fix/small change →
+  minor bump; migration/new feature/breaking change → major bump. Follow it as-is.
+
+## Skills
+
+- **`check-format`** — wraps the Makefile; use before committing/opening a PR, or whenever
+  asked to format/check/lint. Prefer `make check`/`make format` over calling
+  `dart format`/`flutter analyze`/`swiftlint`/`detekt` directly.
+- **`publish-release`** — full release flow: version bump + CHANGELOG propagation across the
+  dependency graph, release branch off `develop`, PR to `develop`, promote `develop` to `main`,
+  then dry-run and real `flutter pub publish` in dependency order
+  (`platform_interface` → `android` → `ios` → `credential_manager`), with explicit per-package
+  confirmation before any real (non-dry-run) publish. Never merges PRs or publishes without
+  the user's explicit go-ahead at each step — these are irreversible/shared actions.
+- **`credential-manager-expert`** — domain-expert reference on the plugin's actual API surface
+  (Dart method signatures, model field nesting, `CredentialException` codes) and native setup
+  (Android Digital Asset Links/proguard/Google OAuth, iOS Associated Domains/AASA/SPM). Built
+  from source, not general WebAuthn knowledge, because the docs site has shipped incorrect
+  method names and field nesting before. Use when writing/reviewing code against this plugin's
+  API or debugging passkey/autofill/Google Sign-In setup.
+
+Skill files live at `.claude/skills/<name>/SKILL.md` (plus `references/` for the expert skill) —
+read them for full step-by-step detail rather than re-deriving the flow from scratch.
+
+## Working conventions in this repo
+
+- CHANGELOG format: newest entry uses `# X.Y.Z` (single `#`), older entries use `## X.Y.Z` —
+  demote the previous top entry when adding a new one.
+- Don't duplicate Swift/Kotlin sources between CocoaPods and SPM, or between lint config and
+  code — one source of truth per concern.
+- Direct pushes to `main` bypassing the PR flow are exceptional and require the user's explicit,
+  specific authorization each time — not implied by earlier approvals.

--- a/docSite/src/components/BackToTop.tsx
+++ b/docSite/src/components/BackToTop.tsx
@@ -16,6 +16,8 @@ const BackToTop = () => {
     <button
       type="button"
       aria-label="Back to top"
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
       onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
       className={cn(
         'fixed bottom-6 right-6 z-40 flex h-10 w-10 items-center justify-center rounded-full border border-border',

--- a/docSite/src/components/DocLayout.tsx
+++ b/docSite/src/components/DocLayout.tsx
@@ -32,11 +32,23 @@ const DocLayout = ({ children }: DocLayoutProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname]);
 
-  // Lock body scroll while the mobile drawer is open
+  // Lock body scroll while the mobile drawer is open. Gated on the same `md` breakpoint the
+  // drawer itself uses, and re-evaluated on resize, so rotating/resizing past `md` with the
+  // drawer still open releases the lock instead of leaving the desktop page unscrollable.
   useEffect(() => {
-    document.body.style.overflow = isSidebarOpen ? 'hidden' : '';
+    if (!isSidebarOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    const mql = window.matchMedia('(max-width: 767px)');
+    const applyLock = () => {
+      document.body.style.overflow = mql.matches ? 'hidden' : previousOverflow;
+    };
+
+    applyLock();
+    mql.addEventListener('change', applyLock);
     return () => {
-      document.body.style.overflow = '';
+      mql.removeEventListener('change', applyLock);
+      document.body.style.overflow = previousOverflow;
     };
   }, [isSidebarOpen]);
 

--- a/docSite/src/components/DocLayout.tsx
+++ b/docSite/src/components/DocLayout.tsx
@@ -6,6 +6,8 @@ import { docNavigation } from '@/lib/docs-utils';
 import Footer from '@/components/Footer';
 import { cn } from '@/lib/utils';
 import { useSidebarToggle } from '@/hooks/useSidebarToggle';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { useDocHeadings } from '@/hooks/useDocHeadings';
 import Header from './Header';
 import TableOfContents, { MobileTableOfContents } from './TableOfContents';
 import Breadcrumbs from './Breadcrumbs';
@@ -19,6 +21,11 @@ const DocLayout = ({ children }: DocLayoutProps) => {
   const { isSidebarOpen, toggleSidebar } = useSidebarToggle();
   const location = useLocation();
   const [scrollProgress, setScrollProgress] = useState(0);
+  const isMobile = useIsMobile();
+  // Owned once here and threaded down to both TableOfContents (desktop rail) and
+  // MobileTableOfContents, which are both always mounted — calling the hook in each would run
+  // its DOM scrape and IntersectionObserver twice for the same page.
+  const { headings, activeId, setActiveId } = useDocHeadings();
 
   // Find current page index for prev/next navigation
   const currentIndex = docNavigation.findIndex(item => item.path === location.pathname);
@@ -32,25 +39,18 @@ const DocLayout = ({ children }: DocLayoutProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname]);
 
-  // Lock body scroll while the mobile drawer is open. Gated on the same `md` breakpoint the
-  // drawer itself uses, and re-evaluated on resize, so rotating/resizing past `md` with the
-  // drawer still open releases the lock instead of leaving the desktop page unscrollable.
+  // Lock body scroll while the mobile drawer is open. Re-evaluated when `isMobile` flips (e.g.
+  // rotating/resizing past `md` with the drawer still open), so it releases the lock instead of
+  // leaving the desktop page unscrollable.
   useEffect(() => {
     if (!isSidebarOpen) return;
 
     const previousOverflow = document.body.style.overflow;
-    const mql = window.matchMedia('(max-width: 767px)');
-    const applyLock = () => {
-      document.body.style.overflow = mql.matches ? 'hidden' : previousOverflow;
-    };
-
-    applyLock();
-    mql.addEventListener('change', applyLock);
+    document.body.style.overflow = isMobile ? 'hidden' : previousOverflow;
     return () => {
-      mql.removeEventListener('change', applyLock);
       document.body.style.overflow = previousOverflow;
     };
-  }, [isSidebarOpen]);
+  }, [isSidebarOpen, isMobile]);
 
   // Handle scroll progress
   useEffect(() => {
@@ -102,7 +102,7 @@ const DocLayout = ({ children }: DocLayoutProps) => {
         <main className="relative py-6 lg:gap-10 lg:py-8 xl:grid xl:grid-cols-[1fr_300px]">
           <div className="mx-auto w-full min-w-0">
             <Breadcrumbs contentId={DOC_CONTENT_ID} />
-            <MobileTableOfContents />
+            <MobileTableOfContents headings={headings} activeId={activeId} setActiveId={setActiveId} />
             <article
               id={DOC_CONTENT_ID}
               className={cn(
@@ -141,7 +141,7 @@ const DocLayout = ({ children }: DocLayoutProps) => {
             </article>
             <Footer />
           </div>
-          <TableOfContents />
+          <TableOfContents headings={headings} activeId={activeId} setActiveId={setActiveId} />
         </main>
       </div>
       <BackToTop />

--- a/docSite/src/components/DocSidebar.tsx
+++ b/docSite/src/components/DocSidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { docNavGroups } from '@/lib/docs-utils';
 import { cn } from '@/lib/utils';
@@ -7,13 +8,34 @@ interface DocSidebarProps {
   toggleSidebar: () => void;
 }
 
-const DocSidebar = ({ toggleSidebar }: DocSidebarProps) => {
+const DocSidebar = ({ isSidebarOpen, toggleSidebar }: DocSidebarProps) => {
   const location = useLocation();
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Track the same `md` breakpoint the drawer's CSS uses, so we only pull the closed drawer's
+  // links out of the tab order on mobile — the desktop sidebar must stay focusable regardless
+  // of `isSidebarOpen`, which is a mobile-only concept.
+  useEffect(() => {
+    const mql = window.matchMedia('(max-width: 767px)');
+    const update = () => setIsMobileViewport(mql.matches);
+    update();
+    mql.addEventListener('change', update);
+    return () => mql.removeEventListener('change', update);
+  }, []);
+
+  // `inert` isn't in this project's JSX typings yet, but it is a real DOM property — set it
+  // imperatively so the closed mobile drawer's links drop out of the tab order without a cast.
+  useEffect(() => {
+    if (wrapperRef.current) {
+      wrapperRef.current.inert = isMobileViewport && !isSidebarOpen;
+    }
+  }, [isMobileViewport, isSidebarOpen]);
 
   const isActive = (path: string) => location.pathname === path;
 
   return (
-    <div className="sidebar-wrapper w-full">
+    <div ref={wrapperRef} className="sidebar-wrapper w-full">
       {docNavGroups.map((group) => (
         <div key={group.label} className="pb-6">
           <h4 className="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground/80">

--- a/docSite/src/components/DocSidebar.tsx
+++ b/docSite/src/components/DocSidebar.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { docNavGroups } from '@/lib/docs-utils';
 import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 interface DocSidebarProps {
   isSidebarOpen: boolean;
@@ -10,27 +11,18 @@ interface DocSidebarProps {
 
 const DocSidebar = ({ isSidebarOpen, toggleSidebar }: DocSidebarProps) => {
   const location = useLocation();
-  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const isMobile = useIsMobile();
   const wrapperRef = useRef<HTMLDivElement>(null);
-
-  // Track the same `md` breakpoint the drawer's CSS uses, so we only pull the closed drawer's
-  // links out of the tab order on mobile — the desktop sidebar must stay focusable regardless
-  // of `isSidebarOpen`, which is a mobile-only concept.
-  useEffect(() => {
-    const mql = window.matchMedia('(max-width: 767px)');
-    const update = () => setIsMobileViewport(mql.matches);
-    update();
-    mql.addEventListener('change', update);
-    return () => mql.removeEventListener('change', update);
-  }, []);
 
   // `inert` isn't in this project's JSX typings yet, but it is a real DOM property — set it
   // imperatively so the closed mobile drawer's links drop out of the tab order without a cast.
+  // Gated on `isMobile` (not just `isSidebarOpen`) so the desktop sidebar, where `isSidebarOpen`
+  // is a mobile-only concept, always stays focusable.
   useEffect(() => {
     if (wrapperRef.current) {
-      wrapperRef.current.inert = isMobileViewport && !isSidebarOpen;
+      wrapperRef.current.inert = isMobile && !isSidebarOpen;
     }
-  }, [isMobileViewport, isSidebarOpen]);
+  }, [isMobile, isSidebarOpen]);
 
   const isActive = (path: string) => location.pathname === path;
 

--- a/docSite/src/components/Header.tsx
+++ b/docSite/src/components/Header.tsx
@@ -45,7 +45,7 @@ const Header = ({ toggleSidebar, isSidebarOpen }: HeaderProps) => {
               <span className="hidden lg:inline-flex">Search documentation...</span>
               <span className="inline-flex lg:hidden">Search...</span>
               <kbd className="pointer-events-none absolute right-1.5 top-1/2 hidden -translate-y-1/2 select-none items-center gap-1 rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px] font-medium sm:flex">
-                <span>⌘</span>K
+                Ctrl/⌘ K
               </kbd>
             </Button>
 

--- a/docSite/src/components/SearchCommand.tsx
+++ b/docSite/src/components/SearchCommand.tsx
@@ -61,19 +61,21 @@ export function SearchCommand({ open, setOpen }: SearchCommandProps) {
             <CommandGroup heading="Results">
               {results.map((result, idx) => {
                 const Icon = result.page.icon;
+                const matchedText = result.match === 'section' ? result.sectionText : result.page.description;
                 return (
                   <CommandItem
                     key={`${result.page.path}-${idx}`}
-                    value={`${result.page.path}-${idx}`}
+                    // Include the text we actually matched on so cmdk's own filtering agrees
+                    // with searchDocs() instead of re-filtering by a path-only value and hiding
+                    // results whose match came from a heading/description rather than the title.
+                    value={`${result.page.path}-${idx}-${result.page.title}-${matchedText}`}
                     onSelect={() => runCommand(() => navigate(result.page.path))}
                     className="flex items-start gap-2.5"
                   >
                     <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
                     <div className="flex flex-col">
                       <span className="font-medium">{result.page.title}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {result.match === 'section' ? result.sectionText : result.page.description}
-                      </span>
+                      <span className="text-xs text-muted-foreground">{matchedText}</span>
                     </div>
                   </CommandItem>
                 );

--- a/docSite/src/components/TableOfContents.tsx
+++ b/docSite/src/components/TableOfContents.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown, ListTree } from 'lucide-react';
 import { useLocation } from 'react-router-dom';
 import { cn } from '@/lib/utils';
-import { buildHeadingUrl, setHeadingHash, useDocHeadings, type TocItem } from '@/hooks/useDocHeadings';
+import { buildHeadingUrl, setHeadingHash, type TocItem } from '@/hooks/useDocHeadings';
 
 interface TocLinksProps {
   headings: TocItem[];
@@ -38,10 +38,17 @@ const TocLinks = ({ headings, activeId, onSelect }: TocLinksProps) => {
   );
 };
 
-// Sticky right-hand rail shown on wide (xl+) viewports.
-const TableOfContents = () => {
-  const { headings, activeId, setActiveId } = useDocHeadings();
+export interface TableOfContentsProps {
+  headings: TocItem[];
+  activeId: string;
+  setActiveId: (id: string) => void;
+}
 
+// Sticky right-hand rail shown on wide (xl+) viewports. Takes heading state as props (rather
+// than calling useDocHeadings itself) because it's rendered alongside MobileTableOfContents on
+// every page — each instance calling the hook independently meant two DOM scrapes and two live
+// IntersectionObservers tracking the same scroll position. DocLayout owns the single hook call.
+const TableOfContents = ({ headings, activeId, setActiveId }: TableOfContentsProps) => {
   if (headings.length === 0) return null;
 
   return (
@@ -60,9 +67,7 @@ const TableOfContents = () => {
 };
 
 // Collapsible "On this page" panel for mobile/tablet, where the rail is hidden.
-export const MobileTableOfContents = () => {
-  const { headings, activeId, setActiveId } = useDocHeadings();
-
+export const MobileTableOfContents = ({ headings, activeId, setActiveId }: TableOfContentsProps) => {
   if (headings.length === 0) return null;
 
   return (

--- a/docSite/src/hooks/useDocHeadings.ts
+++ b/docSite/src/hooks/useDocHeadings.ts
@@ -46,19 +46,36 @@ export function useDocHeadings() {
   }, [location.pathname]);
 
   useEffect(() => {
+    // Declared outside the timeout so the effect's own cleanup can reach it — a cleanup
+    // function returned from inside a setTimeout callback is never called by React.
+    let observer: IntersectionObserver | null = null;
+
     const timer = setTimeout(() => {
       const elements = Array.from(document.querySelectorAll<HTMLElement>('article h2, article h3'));
+      const usedSlugs = new Set<string>();
 
-      const items = elements.map((element) => {
+      const items = elements.map((element, index) => {
         const text = element.textContent?.trim() || '';
 
         if (!element.id) {
-          const slug = text
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, '-')
-            .replace(/(^-|-$)+/g, '');
-          element.id = slug || `heading-${Math.random().toString(36).slice(2, 11)}`;
+          const baseSlug =
+            text
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/(^-|-$)+/g, '') || `heading-${index}`;
+
+          // Deterministic de-duplication (heading, heading-2, heading-3, ...) instead of
+          // Math.random — repeated headings need distinct, stable IDs so TOC links and
+          // shareable deep links keep working across refreshes.
+          let candidate = baseSlug;
+          let suffix = 2;
+          while (usedSlugs.has(candidate)) {
+            candidate = `${baseSlug}-${suffix}`;
+            suffix += 1;
+          }
+          element.id = candidate;
         }
+        usedSlugs.add(element.id);
 
         if (!element.dataset.anchorEnhanced) {
           element.dataset.anchorEnhanced = 'true';
@@ -66,9 +83,13 @@ export function useDocHeadings() {
 
           const anchor = document.createElement('a');
           anchor.setAttribute('aria-label', `Link to ${text || 'section'}`);
+          // Always rendered (no `hidden`/display:none) so the control stays keyboard-focusable;
+          // visibility is opacity-based so it still only *appears* on hover (desktop) or focus.
           anchor.className =
-            'heading-anchor absolute -left-5 top-1/2 hidden -translate-y-1/2 text-muted-foreground ' +
-            'hover:text-primary transition-colors no-underline md:group-hover/heading:inline-flex';
+            'heading-anchor absolute -left-5 top-1/2 inline-flex -translate-y-1/2 items-center ' +
+            'text-muted-foreground opacity-0 no-underline transition-opacity hover:text-primary ' +
+            'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 ' +
+            'focus-visible:ring-primary/50 focus-visible:rounded md:group-hover/heading:opacity-100';
           anchor.innerHTML = ANCHOR_SVG;
           anchor.addEventListener('click', (event) => {
             event.preventDefault();
@@ -105,7 +126,7 @@ export function useDocHeadings() {
         hasScrolledToDeepLink.current = true;
       }
 
-      const observer = new IntersectionObserver(
+      observer = new IntersectionObserver(
         (entries) => {
           entries.forEach((entry) => {
             if (entry.isIntersecting) {
@@ -116,12 +137,13 @@ export function useDocHeadings() {
         { rootMargin: '0px 0px -80% 0px' }
       );
 
-      elements.forEach((element) => observer.observe(element));
-
-      return () => observer.disconnect();
+      elements.forEach((element) => observer?.observe(element));
     }, 100);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      observer?.disconnect();
+    };
   }, [location.pathname, location.search]);
 
   return { headings, activeId, setActiveId };

--- a/docSite/src/lib/search-index.ts
+++ b/docSite/src/lib/search-index.ts
@@ -82,7 +82,7 @@ const sectionsByPath: Record<string, SearchSection[]> = {
     { text: 'How do I clone the repository?' },
     { text: 'How do I initialize Credential Manager?' },
     { text: 'How do I save password-based credentials on Android?' },
-    { text: 'How do handle errors?' },
+    { text: 'How do I handle errors?' },
     { text: 'How do I logout?' },
   ],
   '/contributing': [

--- a/docSite/src/pages/FaqPage.tsx
+++ b/docSite/src/pages/FaqPage.tsx
@@ -121,7 +121,7 @@ if (credentialManager.isSupportedPlatform) {
         <div className="bg-white shadow overflow-hidden rounded-lg border dark:bg-gray-800">
           <div className="px-4 py-5 sm:px-6 bg-gray-50 dark:bg-gray-900">
             <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-white">
-              How do handle errors?
+              How do I handle errors?
             </h3>
           </div>
           <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-5 sm:px-6">

--- a/docSite/src/pages/HomePage.tsx
+++ b/docSite/src/pages/HomePage.tsx
@@ -54,16 +54,14 @@ const HomePage = () => {
         </p>
 
         <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center md:w-auto">
-          <Link to="/installation" className="w-full sm:w-auto">
-            <Button size="lg" className="w-full gap-2 shadow-glow sm:w-auto">
+          <Button size="lg" className="w-full gap-2 shadow-glow sm:w-auto" asChild>
+            <Link to="/installation">
               Get Started <ArrowRight className="h-4 w-4" />
-            </Button>
-          </Link>
-          <Link to="/examples" className="w-full sm:w-auto">
-            <Button variant="outline" size="lg" className="w-full sm:w-auto">
-              View Examples
-            </Button>
-          </Link>
+            </Link>
+          </Button>
+          <Button variant="outline" size="lg" className="w-full sm:w-auto" asChild>
+            <Link to="/examples">View Examples</Link>
+          </Button>
         </div>
 
         <div className="mt-2 flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-muted-foreground">
@@ -133,11 +131,11 @@ await credentialManager.logout();`}
         <p className="max-w-[600px] text-muted-foreground md:text-xl">
           Join developers building secure Flutter applications with Credential Manager.
         </p>
-        <Link to="/installation">
-          <Button size="lg" className="mt-4 gap-2 shadow-glow">
+        <Button size="lg" className="mt-4 gap-2 shadow-glow" asChild>
+          <Link to="/installation">
             Start Integration <ArrowRight className="h-4 w-4" />
-          </Button>
-        </Link>
+          </Link>
+        </Button>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- **CodeRabbit fixes from #76** (all 10 findings addressed):
  - `BackToTop`: hidden button no longer keyboard-focusable (`tabIndex`/`aria-hidden`)
  - `DocLayout`: body scroll lock now releases when resizing past `md` while the drawer is open
  - `DocSidebar`: closed mobile drawer is marked `inert` so its links leave the tab order, without disabling the always-visible desktop sidebar
  - `Header`: search shortcut hint now reads "Ctrl/⌘ K" instead of macOS-only "⌘K"
  - `SearchCommand`: cmdk's own filtering no longer fights `searchDocs()` — matched text is now included in each item's `value`
  - `useDocHeadings`: deterministic heading IDs (indexed suffixes, no more `Math.random()`; duplicate headings get `-2`/`-3` suffixes), heading anchor links are keyboard-focusable (opacity-based visibility + `focus-visible`, not `hidden`), and the `IntersectionObserver` is now actually disconnected on cleanup (previously the cleanup was returned from inside a `setTimeout` callback, where React never sees it)
  - `FaqPage` / `search-index`: fixed "How do handle errors?" typo (present in the live page itself, not just the search index)
  - `HomePage`: stopped nesting `<button>` inside `<a>` on all three CTAs — using shadcn's `Button asChild` pattern instead
- **CI**: `format`/`analyze` now skip on PRs that don't touch Dart (mirrors the existing android/ios path-filter gating) — a docs-only PR was previously paying ~2.5 min for both jobs with nothing to check.
- **New skill**: `credential-manager-expert`, a domain-expert reference on this plugin's actual API (built from source, not general WebAuthn knowledge) plus native Android/iOS setup and the full `CredentialException` code table. Also adds this repo's `CLAUDE.md`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all changed files
- [x] `vite build` succeeds
- [x] CI `dart` path filter validated against workflow YAML syntax
- [ ] Manual browser check (mobile drawer inert behavior, keyboard nav on heading anchors, search results) — not verified visually, no browser tool available in the authoring environment