### PR TITLE
Configurable Web rpId + Google Sign-In flow dropdown in example app

### DIFF
--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -51,7 +51,11 @@ jobs:
         working-directory: packages/credential_manager/example
         env:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-        run: flutter build web --dart-define=GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID"
+          # Must match the exact origin the build is deployed to, or passkey
+          # rpId validation fails. PR previews get a different subdomain per
+          # PR, so only the production (push to main) domain is set here.
+          RP_ID: ${{ github.event_name == 'push' && 'credential-manager-compose-example.netlify.app' || 'localhost' }}
+        run: flutter build web --dart-define=GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" --dart-define=RP_ID="$RP_ID"
 
       - name: Install Netlify CLI
         if: steps.check.outputs.configured == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ packages/credential_manager/example/android/.kotlin/
 
 # macOS
 .DS_Store
+# Local Netlify folder
+.netlify

--- a/packages/credential_manager/example/lib/main.dart
+++ b/packages/credential_manager/example/lib/main.dart
@@ -8,9 +8,15 @@ import 'dart:developer';
 //   flutter run --dart-define=GOOGLE_CLIENT_ID=<your-client-id>.apps.googleusercontent.com
 // CI supplies this from the GOOGLE_CLIENT_ID repository secret.
 const String googleClientId = String.fromEnvironment('GOOGLE_CLIENT_ID');
-// For localhost testing, use "localhost" as rpId
-// For production, use your actual domain
-final String rpId = CredentialManagerPlatformManager.instance.isWeb ? "localhost" : "blogs-deeplink-example.vercel.app";
+// Web's rpId must match the origin the app is actually served from, so it's
+// configurable at build/run time, e.g.:
+//   flutter run --dart-define=RP_ID=localhost
+//   flutter build web --dart-define=RP_ID=credential-manager-compose-example.netlify.app
+// Defaults to "localhost" for local web development. Android/iOS keep a fixed
+// domain since their rpId is tied to the hosted Digital Asset Links /
+// apple-app-site-association files, not the client build.
+const String _webRpId = String.fromEnvironment('RP_ID', defaultValue: 'localhost');
+final String rpId = CredentialManagerPlatformManager.instance.isWeb ? _webRpId : "blogs-deeplink-example.vercel.app";
 final CredentialManager credentialManager = CredentialManager();
 
 void main() async {
@@ -122,6 +128,12 @@ class _LoginScreenState extends State<LoginScreen> {
   late CredentialLoginOptions passKeyLoginOption;
   bool isGoogleEnabled = false;
 
+  // Google Sign-In flow, selectable via the dropdown shown for Android/Web:
+  // - false: One Tap / passive (GetGoogleIdOption on Android, One Tap on Web)
+  // - true: button/active flow (GetSignInWithGoogleOption on Android, a
+  //   rendered Google button click on Web)
+  bool useGoogleButtonFlow = false;
+
   @override
   void initState() {
     super.initState();
@@ -198,6 +210,8 @@ class _LoginScreenState extends State<LoginScreen> {
                                 icon: Icons.key,
                               ),
                               if (isGoogleSignInSupported) ...[
+                                const SizedBox(height: 12),
+                                _buildGoogleFlowDropdown(),
                                 const SizedBox(height: 12),
                                 _buildActionButton(
                                   "Register with Google",
@@ -299,6 +313,25 @@ class _LoginScreenState extends State<LoginScreen> {
       avatar: Icon(icon, size: 18, color: Theme.of(context).colorScheme.primary),
       label: Text('Running on $label'),
       visualDensity: VisualDensity.compact,
+    );
+  }
+
+  /// Lets the user pick between Google's One Tap/passive flow and its
+  /// button/active flow. Both platforms that support Google Sign-In
+  /// (Android + Web) accept the same `useButtonFlow` bool, so one dropdown
+  /// covers both - see `saveGoogleCredential(bool useButtonFlow, {String? nonce})`.
+  Widget _buildGoogleFlowDropdown() {
+    return DropdownButtonFormField<bool>(
+      initialValue: useGoogleButtonFlow,
+      decoration: const InputDecoration(
+        labelText: "Google Sign-In flow",
+        prefixIcon: Icon(Icons.tune),
+      ),
+      items: const [
+        DropdownMenuItem(value: false, child: Text("One Tap (passive)")),
+        DropdownMenuItem(value: true, child: Text("Button flow (active)")),
+      ],
+      onChanged: (value) => setState(() => useGoogleButtonFlow = value ?? false),
     );
   }
 
@@ -443,6 +476,7 @@ class _LoginScreenState extends State<LoginScreen> {
       // FedCM IdentityProvider on web). Supply your own when you need to tie
       // the sign-in request to a value your backend already issued.
       final credential = await credentialManager.saveGoogleCredential(
+        useButtonFlow: useGoogleButtonFlow,
         nonce: EncryptData.getEncodedChallenge(),
       );
       _showSnackBar("Successfully retrieved credential");


### PR DESCRIPTION
## Summary
Follow-up to #78 (already merged) — a couple of loose ends from testing the deployed web example:

- `rpId` on Web is now overridable via `--dart-define=RP_ID=...` (defaults to `localhost` for local dev). The Netlify production deploy passes the actual deployed domain (`credential-manager-compose-example.netlify.app`) so passkey rpId validation matches the serving origin.
- The example app's Google Sign-In section now has a dropdown to pick between One Tap/passive and button/active flow (`useButtonFlow`), instead of it being hardcoded to passive — same bool works for both Android and Web.
- Minor: gitignore the local `.netlify` folder created by `netlify sites:create`.

## Test plan
- [x] `flutter analyze` clean
- [x] `dart format` compliant
- [x] Rebuilt and redeployed the live Netlify example with the new `--dart-define` values to confirm the build succeeds end-to-end