### PR TITLE
Fix web asset path, force light theme, responsive UI polish

### DIFF
--- a/.claude/skills/credential-manager-expert/SKILL.md
+++ b/.claude/skills/credential-manager-expert/SKILL.md
@@ -80,7 +80,7 @@ Web must add this to `web/index.html`, before Flutter boots (see `references/web
 full guide):
 
 ```html
-<script src="packages/credential_manager_web/web/passkey_authenticator.js"></script>
+<script src="assets/packages/credential_manager_web/web/passkey_authenticator.js"></script>
 ```
 
 Without it, `init()` throws `CredentialException(code: 101, message: 'Initialization failure: JavaScript not loaded')`.

--- a/.claude/skills/credential-manager-expert/references/troubleshooting.md
+++ b/.claude/skills/credential-manager-expert/references/troubleshooting.md
@@ -83,7 +83,7 @@ it will fail to compile.
 See `references/web-setup.md` for the full setup guide. Quick triage:
 
 - **`CredentialException(code: 101, message: 'Initialization failure: JavaScript not loaded')`** →
-  the `<script src="packages/credential_manager_web/web/passkey_authenticator.js">` tag is missing
+  the `<script src="assets/packages/credential_manager_web/web/passkey_authenticator.js">` tag is missing
   from `web/index.html`, or the app is served from a base path where that relative path doesn't
   resolve.
 - **Error 400 from Google after picking an account, or sign-in silently fails** → the app's exact

--- a/.claude/skills/credential-manager-expert/references/web-setup.md
+++ b/.claude/skills/credential-manager-expert/references/web-setup.md
@@ -14,10 +14,16 @@ that runs on Web must add this `<script>` tag to `web/index.html`, **before** Fl
 
 ```html
 <body>
-  <script src="packages/credential_manager_web/web/passkey_authenticator.js"></script>
+  <script src="assets/packages/credential_manager_web/web/passkey_authenticator.js"></script>
   <script src="flutter_bootstrap.js" async></script>
 </body>
 ```
+
+Note the `assets/` prefix: `flutter build web` bundles plugin `web/` assets under
+`build/web/assets/packages/<pkg>/...`, not `build/web/packages/<pkg>/...` — there is no top-level
+`packages/` directory in a static build output. `flutter run -d chrome`'s dev server resolves the
+unprefixed `packages/...` path too (via its own asset resolver), which is why this bug can go
+unnoticed until a real static deploy (e.g. Netlify) 404s on it.
 
 Skip this and `CredentialManager().init(...)` throws:
 

--- a/docSite/src/pages/ConfigurationPage.tsx
+++ b/docSite/src/pages/ConfigurationPage.tsx
@@ -244,7 +244,7 @@ pod deintegrate`}
         language="plaintext"
         code={`<body>
   <!-- Load CredentialManagerWeb before Flutter -->
-  <script src="packages/credential_manager_web/web/passkey_authenticator.js"></script>
+  <script src="assets/packages/credential_manager_web/web/passkey_authenticator.js"></script>
   <script src="flutter_bootstrap.js" async></script>
 </body>`}
       />

--- a/docSite/src/pages/UsagePage.tsx
+++ b/docSite/src/pages/UsagePage.tsx
@@ -276,7 +276,7 @@ if (!credentialManager.isGmsAvailable) {
         <CodeBlock
           language="plaintext"
           code={`<!-- web/index.html, inside <body>, before flutter_bootstrap.js -->
-<script src="packages/credential_manager_web/web/passkey_authenticator.js"></script>`}
+<script src="assets/packages/credential_manager_web/web/passkey_authenticator.js"></script>`}
         />
       </div>
 

--- a/packages/credential_manager/example/lib/main.dart
+++ b/packages/credential_manager/example/lib/main.dart
@@ -47,7 +47,7 @@ class MyApp extends StatelessWidget {
       title: "Credential Manager Example",
       debugShowCheckedModeBanner: false,
       theme: buildAppTheme(Brightness.light),
-      darkTheme: buildAppTheme(Brightness.dark),
+      themeMode: ThemeMode.light,
       home: const LoginScreen(),
     );
   }
@@ -157,7 +157,10 @@ class _LoginScreenState extends State<LoginScreen> {
   @override
   Widget build(BuildContext context) {
     final isGmsAvailable = credentialManager.isGmsAvailable;
+    final isCompact = MediaQuery.sizeOf(context).width < 600;
+
     return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surfaceContainerLowest,
       appBar: AppBar(
         title: const Text("Credential Manager"),
         centerTitle: true,
@@ -171,68 +174,82 @@ class _LoginScreenState extends State<LoginScreen> {
                   child: Opacity(
                     opacity: isLoading ? 0.5 : 1,
                     child: SingleChildScrollView(
-                      padding: const EdgeInsets.all(24),
-                      child: _buildAutofillGroup(
-                        Form(
-                          key: _formKey,
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.stretch,
-                            children: [
-                              _buildHeader(),
-                              const SizedBox(height: 32),
-                              _buildInputField(
-                                "Username",
-                                (value) => username = value,
-                                icon: Icons.person_outline,
-                              ),
-                              if (createPassKey) ...[
-                                const SizedBox(height: 16),
-                                _buildInputField(
-                                  "Password",
-                                  (value) => password = value,
-                                  isPassword: true,
-                                  icon: Icons.lock_outline,
+                      padding: EdgeInsets.symmetric(horizontal: isCompact ? 16 : 24, vertical: 24),
+                      child: Center(
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 460),
+                          child: _buildAutofillGroup(
+                            Card(
+                              elevation: isCompact ? 0 : 1,
+                              color: isCompact ? Colors.transparent : Theme.of(context).colorScheme.surface,
+                              surfaceTintColor: Theme.of(context).colorScheme.surfaceTint,
+                              margin: EdgeInsets.zero,
+                              child: Padding(
+                                padding: EdgeInsets.all(isCompact ? 0 : 32),
+                                child: Form(
+                                  key: _formKey,
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                                    children: [
+                                      _buildHeader(),
+                                      const SizedBox(height: 32),
+                                      _buildInputField(
+                                        "Username",
+                                        (value) => username = value,
+                                        icon: Icons.person_outline,
+                                      ),
+                                      if (createPassKey) ...[
+                                        const SizedBox(height: 16),
+                                        _buildInputField(
+                                          "Password",
+                                          (value) => password = value,
+                                          isPassword: true,
+                                          icon: Icons.lock_outline,
+                                        ),
+                                      ],
+                                      const SizedBox(height: 24),
+                                      _buildSectionTitle("Registration"),
+                                      const SizedBox(height: 12),
+                                      _buildActionButton(
+                                        "Register with Password",
+                                        onRegister,
+                                        icon: Icons.password,
+                                        isPrimary: true,
+                                      ),
+                                      const SizedBox(height: 12),
+                                      _buildActionButton(
+                                        "Register with Passkey",
+                                        onRegisterWithPassKey,
+                                        icon: Icons.key,
+                                      ),
+                                      if (isGoogleSignInSupported) ...[
+                                        const SizedBox(height: 12),
+                                        _buildGoogleFlowDropdown(),
+                                        const SizedBox(height: 12),
+                                        _buildActionButton(
+                                          "Register with Google",
+                                          onGoogleSignIn,
+                                          icon: Icons.g_mobiledata,
+                                        ),
+                                      ],
+                                      const SizedBox(height: 24),
+                                      _buildSectionTitle("Login"),
+                                      const SizedBox(height: 12),
+                                      _buildActionButton(
+                                        CredentialManagerPlatformManager.instance.isAndroid
+                                            ? "Login (All Methods)"
+                                            : isGoogleSignInSupported
+                                                ? "Login (Passkey + Google)"
+                                                : "Login with Passkey",
+                                        onLogin,
+                                        icon: Icons.login,
+                                        isPrimary: true,
+                                      ),
+                                    ],
+                                  ),
                                 ),
-                              ],
-                              const SizedBox(height: 24),
-                              _buildSectionTitle("Registration"),
-                              const SizedBox(height: 12),
-                              _buildActionButton(
-                                "Register with Password",
-                                onRegister,
-                                icon: Icons.password,
-                                isPrimary: true,
                               ),
-                              const SizedBox(height: 12),
-                              _buildActionButton(
-                                "Register with Passkey",
-                                onRegisterWithPassKey,
-                                icon: Icons.key,
-                              ),
-                              if (isGoogleSignInSupported) ...[
-                                const SizedBox(height: 12),
-                                _buildGoogleFlowDropdown(),
-                                const SizedBox(height: 12),
-                                _buildActionButton(
-                                  "Register with Google",
-                                  onGoogleSignIn,
-                                  icon: Icons.g_mobiledata,
-                                ),
-                              ],
-                              const SizedBox(height: 24),
-                              _buildSectionTitle("Login"),
-                              const SizedBox(height: 12),
-                              _buildActionButton(
-                                CredentialManagerPlatformManager.instance.isAndroid
-                                    ? "Login (All Methods)"
-                                    : isGoogleSignInSupported
-                                        ? "Login (Passkey + Google)"
-                                        : "Login with Passkey",
-                                onLogin,
-                                icon: Icons.login,
-                                isPrimary: true,
-                              ),
-                            ],
+                            ),
                           ),
                         ),
                       ),

--- a/packages/credential_manager/example/web/index.html
+++ b/packages/credential_manager/example/web/index.html
@@ -38,11 +38,18 @@
     // Load the JavaScript bundle - try multiple possible paths
     (function() {
       var script = document.createElement('script');
-      script.src = 'packages/credential_manager_web/web/passkey_authenticator.js';
+      script.src = 'assets/packages/credential_manager_web/web/passkey_authenticator.js';
       script.onerror = function() {
-        // Try alternative path
-        script.src = 'passkey_authenticator.js';
-        document.head.appendChild(script);
+        // Try alternative path (flutter run dev server)
+        var fallback = document.createElement('script');
+        fallback.src = 'packages/credential_manager_web/web/passkey_authenticator.js';
+        fallback.onerror = function() {
+          // Final fallback
+          var rootFallback = document.createElement('script');
+          rootFallback.src = 'passkey_authenticator.js';
+          document.head.appendChild(rootFallback);
+        };
+        document.head.appendChild(fallback);
       };
       document.head.appendChild(script);
     })();

--- a/packages/credential_manager_web/GOOGLE_SIGNIN_SETUP.md
+++ b/packages/credential_manager_web/GOOGLE_SIGNIN_SETUP.md
@@ -137,7 +137,7 @@ the forwarded click on Google's hidden button. Make sure `saveGoogleCredential` 
 click handler (no `await` before it) and isn't delayed by other work.
 
 ### Initialization error: "CredentialManagerWeb JavaScript bundle not found"
-The `<script>` tag for `packages/credential_manager_web/web/passkey_authenticator.js` is missing from
+The `<script>` tag for `assets/packages/credential_manager_web/web/passkey_authenticator.js` is missing from
 `web/index.html`, or the app was served from a path where that relative path doesn't resolve.
 
 ## Additional Resources

--- a/packages/credential_manager_web/README.md
+++ b/packages/credential_manager_web/README.md
@@ -26,7 +26,7 @@ Add this to `web/index.html`, before `flutter_bootstrap.js`, in every app that d
 **not** injected automatically):
 
 ```html
-<script src="packages/credential_manager_web/web/passkey_authenticator.js"></script>
+<script src="assets/packages/credential_manager_web/web/passkey_authenticator.js"></script>
 ```
 
 ### 2. Google Sign-In (Google Identity Services)


### PR DESCRIPTION
## Summary
- **Bug fix**: `web/index.html`'s `<script>` tag pointed at `packages/credential_manager_web/web/passkey_authenticator.js`, but `flutter build web` actually nests plugin web assets under `build/web/assets/packages/<pkg>/...` — there's no top-level `packages/` dir in a static build. This 404'd silently on the deployed Netlify site (only worked under `flutter run`'s dev server, which resolves the unprefixed path too). Fixed with a 3-level fallback (`assets/packages/...` → `packages/...` → same-directory), and updated the docs/skill references that quoted the old path.
- **UI polish**: the example app now forces the light theme (previously followed system dark mode) and lays the login form out in a centered, max-width card instead of stretching full-bleed on wide viewports — much more presentable on desktop web while staying edge-to-edge/chrome-free on narrow (<600px) mobile viewports.

## Test plan
- [x] `flutter analyze` clean
- [x] `dart format` compliant
- [x] Verified via browser screenshot (desktop 1400x900 viewport): centered card, light theme, Google Sign-In flow dropdown all render correctly
- [x] Confirmed the actual `flutter build web` output path (`build/web/assets/packages/credential_manager_web/web/passkey_authenticator.js`) matches the new script src