### PR TITLE
Fix CI path filters, add docs build check, Netlify main-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,16 @@ jobs:
       android: ${{ steps.filter.outputs.android }}
       ios: ${{ steps.filter.outputs.ios }}
       web: ${{ steps.filter.outputs.web }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # Note: these intentionally point at buildable source (lib/**,
+          # android/**, ios/**, web/**, pubspec.yaml, analysis_options.yaml),
+          # not whole-package globs - a package's own *.md docs shouldn't
+          # trigger its native build/lint job.
           filters: |
             dart:
               - 'packages/**/*.dart'
@@ -26,19 +31,46 @@ jobs:
               - 'pubspec.yaml'
               - '.github/workflows/ci.yml'
             android:
-              - 'packages/credential_manager_android/**'
-              - 'packages/credential_manager_platform_interface/**'
-              - 'packages/credential_manager/**'
+              - 'packages/credential_manager_android/android/**'
+              - 'packages/credential_manager_android/lib/**'
+              - 'packages/credential_manager_android/pubspec.yaml'
+              - 'packages/credential_manager_android/analysis_options.yaml'
+              - 'packages/credential_manager_platform_interface/lib/**'
+              - 'packages/credential_manager_platform_interface/pubspec.yaml'
+              - 'packages/credential_manager_platform_interface/analysis_options.yaml'
+              - 'packages/credential_manager/lib/**'
+              - 'packages/credential_manager/pubspec.yaml'
+              - 'packages/credential_manager/analysis_options.yaml'
+              - 'packages/credential_manager/example/**'
               - '.github/workflows/ci.yml'
             ios:
-              - 'packages/credential_manager_ios/**'
-              - 'packages/credential_manager_platform_interface/**'
-              - 'packages/credential_manager/**'
+              - 'packages/credential_manager_ios/ios/**'
+              - 'packages/credential_manager_ios/lib/**'
+              - 'packages/credential_manager_ios/pubspec.yaml'
+              - 'packages/credential_manager_ios/analysis_options.yaml'
+              - 'packages/credential_manager_platform_interface/lib/**'
+              - 'packages/credential_manager_platform_interface/pubspec.yaml'
+              - 'packages/credential_manager_platform_interface/analysis_options.yaml'
+              - 'packages/credential_manager/lib/**'
+              - 'packages/credential_manager/pubspec.yaml'
+              - 'packages/credential_manager/analysis_options.yaml'
+              - 'packages/credential_manager/example/**'
               - '.github/workflows/ci.yml'
             web:
-              - 'packages/credential_manager_web/**'
-              - 'packages/credential_manager_platform_interface/**'
-              - 'packages/credential_manager/**'
+              - 'packages/credential_manager_web/lib/**'
+              - 'packages/credential_manager_web/web/**'
+              - 'packages/credential_manager_web/pubspec.yaml'
+              - 'packages/credential_manager_web/analysis_options.yaml'
+              - 'packages/credential_manager_platform_interface/lib/**'
+              - 'packages/credential_manager_platform_interface/pubspec.yaml'
+              - 'packages/credential_manager_platform_interface/analysis_options.yaml'
+              - 'packages/credential_manager/lib/**'
+              - 'packages/credential_manager/pubspec.yaml'
+              - 'packages/credential_manager/analysis_options.yaml'
+              - 'packages/credential_manager/example/**'
+              - '.github/workflows/ci.yml'
+            docs:
+              - 'docSite/**'
               - '.github/workflows/ci.yml'
 
   format:
@@ -167,3 +199,23 @@ jobs:
         env:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
         run: flutter build web --dart-define=GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID"
+
+  docs-build:
+    name: Docs site build check
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docSite
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: docSite/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build docs (verify only, no deploy)
+        run: npm run build

--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -1,19 +1,17 @@
 name: Deploy Web Example to Netlify
 
 on:
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'packages/credential_manager_web/**'
-      - 'packages/credential_manager_platform_interface/**'
-      - 'packages/credential_manager/**'
-      - '.github/workflows/netlify-deploy.yml'
   push:
     branches: [main]
     paths:
-      - 'packages/credential_manager_web/**'
-      - 'packages/credential_manager_platform_interface/**'
-      - 'packages/credential_manager/**'
+      - 'packages/credential_manager_web/lib/**'
+      - 'packages/credential_manager_web/web/**'
+      - 'packages/credential_manager_web/pubspec.yaml'
+      - 'packages/credential_manager_platform_interface/lib/**'
+      - 'packages/credential_manager_platform_interface/pubspec.yaml'
+      - 'packages/credential_manager/lib/**'
+      - 'packages/credential_manager/pubspec.yaml'
+      - 'packages/credential_manager/example/**'
       - '.github/workflows/netlify-deploy.yml'
 
 jobs:
@@ -52,28 +50,16 @@ jobs:
         env:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           # Must match the exact origin the build is deployed to, or passkey
-          # rpId validation fails. PR previews get a different subdomain per
-          # PR, so only the production (push to main) domain is set here.
-          RP_ID: ${{ github.event_name == 'push' && 'credential-manager-compose-example.netlify.app' || 'localhost' }}
+          # rpId validation fails.
+          RP_ID: credential-manager-compose-example.netlify.app
         run: flutter build web --dart-define=GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID" --dart-define=RP_ID="$RP_ID"
 
       - name: Install Netlify CLI
         if: steps.check.outputs.configured == 'true'
         run: npm install -g netlify-cli@17
 
-      - name: Deploy preview (pull request)
-        if: steps.check.outputs.configured == 'true' && github.event_name == 'pull_request'
-        working-directory: packages/credential_manager/example
-        run: |
-          netlify deploy \
-            --dir=build/web \
-            --auth="$NETLIFY_AUTH_TOKEN" \
-            --site="$NETLIFY_SITE_ID" \
-            --message="PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}" \
-            --alias="pr-${{ github.event.pull_request.number }}"
-
-      - name: Deploy production (push to main)
-        if: steps.check.outputs.configured == 'true' && github.event_name == 'push'
+      - name: Deploy to Netlify (production)
+        if: steps.check.outputs.configured == 'true'
         working-directory: packages/credential_manager/example
         run: |
           netlify deploy \


### PR DESCRIPTION
## Summary
- **Narrowed the android/ios/web path filters** in `ci.yml`: they previously matched whole-package globs (e.g. `packages/credential_manager_web/**`), so editing a package's own README/markdown docs triggered its native build/lint job even though nothing buildable changed. Now scoped to actual buildable source (`lib/**`, `android/**`, `ios/**`, `web/**`, `pubspec.yaml`, `analysis_options.yaml`).
- **Added a `docs-build` job** (gated on a new `docs` path filter for `docSite/**`) that runs `npm run build` on PRs — catches a broken docs site before merge. Build-check only, no deploy (deployment stays in `docs-deploy.yml`, on push to main, unchanged).
- **`netlify-deploy.yml` no longer triggers on `pull_request`** — it now only runs on push to `main`, so PRs no longer spin up a Netlify preview deploy.

## Test plan
- [x] Parsed the inner `dorny/paths-filter` YAML filter string standalone to confirm each filter resolves to a flat list of glob strings (no nested-array bug)
- [x] Validated both workflow files with `yaml.safe_load`
- [ ] CI on this PR itself should now correctly skip android/ios/web/Detekt/SwiftLint jobs, since this PR only touches `.github/workflows/*.yml` (included in every filter intentionally, so they'll still run once — expected, since workflow changes should be verified)