### PR TITLE
chore: release v2.1.0 (credential_manager_web) / v3.1.0 (credential_manager)

### DIFF
--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-# 3.0.1
+# 3.1.0
+- Bumped `credential_manager_web` to `^2.1.0`, which fixes the `passkey_authenticator.js` `<script>`
+  path documented for Web setup (was 404ing on static deploys; see that package's CHANGELOG)
+- Removed a stale `publish_to: none` left over from a previous release prep that would have blocked
+  this package from publishing to pub.dev
+- No breaking changes to the Dart API
+
+## 3.0.1
 - Bumped `credential_manager_ios` to `^3.0.1` and `credential_manager_android` to `^3.0.1`, both of which add native static analysis (SwiftLint, Detekt) with no functional or API changes
 - No breaking changes to the Dart API
 

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -3,10 +3,9 @@ description: >
   Credential Manager plugin. Provides one-tap login functionality and stores credentials
   in the user's Google account on Android and in the Keychain on iOS.
 
-version: 3.0.1
+version: 3.1.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
-publish_to: none
 
 environment:
   sdk: '>=3.5.0 <4.0.0'
@@ -20,7 +19,7 @@ dependencies:
   credential_manager_platform_interface: ^2.0.8
   credential_manager_android: ^3.0.1
   credential_manager_ios: ^3.0.1
-  credential_manager_web: ^2.0.7
+  credential_manager_web: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/credential_manager_web/CHANGELOG.md
+++ b/packages/credential_manager_web/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.1.0
+
+- Fixed the `<script>` tag path documented in the README, Google Sign-In setup guide, and example
+  app's `web/index.html`: `flutter build web` places plugin `web/` assets under
+  `assets/packages/<pkg>/...`, not a top-level `packages/<pkg>/...` — the old path only happened to
+  resolve under `flutter run`'s dev server, and 404'd on real static deploys (e.g. Netlify)
+- No changes to the package's Dart/JS source or public API
+
 ## 2.0.7
 
 - Initial release of Web implementation package

--- a/packages/credential_manager_web/pubspec.yaml
+++ b/packages/credential_manager_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: credential_manager_web
 description: Web implementation of the credential_manager plugin using Web Authentication API (WebAuthn) and Credential Management API.
-version: 2.0.7
+version: 2.1.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 publish_to: none


### PR DESCRIPTION
Promotes develop to main to publish:
- `credential_manager_web` 2.0.7 → 2.1.0
- `credential_manager` 3.0.1 → 3.1.0

See #85 for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Web static deployments so passkey authentication scripts load correctly instead of returning 404 errors.
  * Updated documented script paths for Web builds, including setup guides and examples.

* **Release**
  * Released `credential_manager` 3.1.0 and `credential_manager_web` 2.1.0.
  * No breaking changes to the Dart API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->