### PR TITLE
chore: release v2.1.0 (credential_manager_web) / v4.0.0 (credential_manager)

### DIFF
--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-# 3.1.0
-- Bumped `credential_manager_web` to `^2.1.0`, which fixes the `passkey_authenticator.js` `<script>`
-  path documented for Web setup (was 404ing on static deploys; see that package's CHANGELOG)
+# 4.0.0
+- **New: Web platform support.** Adds `credential_manager_web: ^2.1.0` as a dependency, bringing
+  passkey (WebAuthn), password credential, and Google Sign-In (GIS/FedCM) support to Flutter Web —
+  see `credential_manager_web`'s own CHANGELOG and README for setup (a `<script>` tag is required in
+  `web/index.html`, not wired up automatically)
 - Removed a stale `publish_to: none` left over from a previous release prep that would have blocked
   this package from publishing to pub.dev
-- No breaking changes to the Dart API
+- No breaking changes to the existing Android/iOS Dart API
 
 ## 3.0.1
 - Bumped `credential_manager_ios` to `^3.0.1` and `credential_manager_android` to `^3.0.1`, both of which add native static analysis (SwiftLint, Detekt) with no functional or API changes

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Credential Manager plugin. Provides one-tap login functionality and stores credentials
   in the user's Google account on Android and in the Keychain on iOS.
 
-version: 3.1.0
+version: 4.0.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 

--- a/packages/credential_manager_web/pubspec.yaml
+++ b/packages/credential_manager_web/pubspec.yaml
@@ -3,7 +3,6 @@ description: Web implementation of the credential_manager plugin using Web Authe
 version: 2.1.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
-publish_to: none
 environment:
   sdk: '>=3.5.0 <4.0.0'
   flutter: '>=3.3.0'


### PR DESCRIPTION
Promotes develop to main to publish:
- `credential_manager_web` 2.1.0 (first pub.dev release)
- `credential_manager` 4.0.0 (debut of Web platform support)

See #85 and #87 for details.