### PR TITLE
fix: PR #79 CodeRabbit findings + critical platform_interface version mismatch

### DIFF
--- a/.claude/skills/credential-manager-expert/references/api-reference.md
+++ b/.claude/skills/credential-manager-expert/references/api-reference.md
@@ -38,6 +38,11 @@ rendered Google Sign-In button click (Web). `false` = the newer Credential Manag
 (Android) or Google One Tap (Web). Android + Web only — `saveGoogleCredential` is not implemented
 on iOS.
 
+On Web, `googleClientId` must be provided during `init()` for Google Sign-In; omitting it causes
+`saveGoogleCredential()` to throw a `CredentialException` (code 505, "Google credential decode
+error" — the JS side's "Google Client ID is not configured" error gets wrapped generically, unlike
+Android's dedicated code 503 for the same situation).
+
 `nonce`: optional caller-supplied nonce for replay protection, added alongside Web support. Omit it
 and a securely-generated random nonce is used instead (Android: `SecureRandom`; Web:
 `crypto.getRandomValues`) — mirrors the capabilities Android already configured on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: Detect changed paths
@@ -188,6 +191,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: subosito/flutter-action@v2
         with:
           channel: stable

--- a/docSite/src/pages/ConfigurationPage.tsx
+++ b/docSite/src/pages/ConfigurationPage.tsx
@@ -89,7 +89,12 @@ Allow: /.well-known/`}
         <li className="mb-2">Go to the <a href="https://console.cloud.google.com/" target="_blank" rel="noopener noreferrer">Google Cloud Console</a></li>
         <li className="mb-2">Create or select a project</li>
         <li className="mb-2">Configure the OAuth consent screen</li>
-        <li className="mb-2">Create OAuth client ID credentials for Android and Web</li>
+        <li className="mb-2">
+          Create OAuth client ID credentials: an <strong>Android</strong> type client (tied to your SHA-1 +
+          package name, so Google trusts the calling app — you don't use this client ID directly in code), and
+          a separate <strong>Web application</strong> type client (its client ID is what you actually pass as{' '}
+          <code>googleClientId</code>, for both Android and Web)
+        </li>
         <li className="mb-2">
           <p>For Android, obtain SHA-1 certificate fingerprint:</p>
           <CodeBlock code={`cd android && ./gradlew signingReport`} language="bash" />
@@ -256,9 +261,9 @@ pod deintegrate`}
         <a href="https://developers.google.com/identity/gsi/web/guides/overview" target="_blank" rel="noopener noreferrer">
           Google Identity Services
         </a>{' '}
-        (GIS), which uses FedCM under the hood in supporting browsers. Reuse the same Web OAuth client ID you created
-        for Android above, but this time fill in <strong>Authorized JavaScript origins</strong> with every origin
-        you'll run the app from:
+        (GIS), which uses FedCM under the hood in supporting browsers. Reuse the same <strong>Web application</strong>{' '}
+        OAuth client ID from above (not the Android-type client) — but this time fill in{' '}
+        <strong>Authorized JavaScript origins</strong> with every origin you'll run the app from:
       </p>
       <ul className="list-disc pl-6 mb-6">
         <li className="mb-2">Local development: <code>http://localhost:PORT</code> (pick a fixed port; avoid 5000/7000 on macOS — reserved by AirPlay Receiver / ControlCenter)</li>

--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-# 4.0.0
+# 4.1.0
+- **Fixes a critical issue in 4.0.0**: that release depended on `credential_manager_platform_interface:
+  ^2.0.8`, but the actual pub.dev `2.0.8` release predates the `nonce` parameter this package's
+  Google Sign-In call relies on, breaking `flutter pub get`/analysis for anyone resolving from
+  pub.dev (the pana/dartdoc score drop and `UNDEFINED_NAMED_PARAMETER` error some users saw). Now
+  depends on `credential_manager_platform_interface: ^3.0.0`, which correctly ships `nonce`.
+- Bumped `credential_manager_android` to `^3.1.0` and `credential_manager_ios` to `^3.1.0` (nonce
+  fix, plus iOS now fails explicitly instead of silently/uncaught for two unimplemented methods —
+  see their own CHANGELOGs) and `credential_manager_web` to `^2.2.0` (JS bug fixes — see its
+  CHANGELOG)
+- No breaking changes to this package's own public Dart API
+
+## 4.0.0
 - **New: Web platform support.** Adds `credential_manager_web: ^2.1.0` as a dependency, bringing
   passkey (WebAuthn), password credential, and Google Sign-In (GIS/FedCM) support to Flutter Web —
   see `credential_manager_web`'s own CHANGELOG and README for setup (a `<script>` tag is required in

--- a/packages/credential_manager/example/lib/home_screen.dart
+++ b/packages/credential_manager/example/lib/home_screen.dart
@@ -277,6 +277,13 @@ class HomeScreen extends StatelessWidget {
         Navigator.of(context).pop();
       }
     } else {
+      if (CredentialManagerPlatformManager.instance.isIOS) {
+        try {
+          await credentialManager.logout();
+        } catch (_) {
+          // No native iOS logout handler is wired up yet; nothing server-side to clear either way.
+        }
+      }
       // iOS and Web have nothing server-side to clear; just leave this screen.
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Logged out successfully')),

--- a/packages/credential_manager/example/lib/main.dart
+++ b/packages/credential_manager/example/lib/main.dart
@@ -30,6 +30,8 @@ void main() async {
       );
     } on CredentialException catch (e) {
       log("Error initializing credential manager: ${e.message}");
+    } catch (e) {
+      log("Error initializing credential manager: $e");
     }
   }
   log("current platform: ${CredentialManagerPlatformManager.instance.isAndroid ? "android" : CredentialManagerPlatformManager.instance.isIOS ? "ios" : "web"}");
@@ -142,7 +144,7 @@ class _LoginScreenState extends State<LoginScreen> {
       rpId: rpId,
       userVerification: "required",
       //only for ios, true only when we want to show the passkey popup on keyboard otherwise false
-      conditionalUI: true,
+      conditionalUI: CredentialManagerPlatformManager.instance.isIOS,
     );
     isGoogleEnabled = googleClientId.isNotEmpty;
   }

--- a/packages/credential_manager/example/web/index.html
+++ b/packages/credential_manager/example/web/index.html
@@ -35,18 +35,30 @@
 <body>
   <!-- Load CredentialManagerWeb JavaScript before Flutter -->
   <script>
-    // Load the JavaScript bundle - try multiple possible paths
+    // Load the JavaScript bundle - try multiple possible paths. flutter_bootstrap.js is only
+    // loaded once this resolves (success or final failure), so Flutter never reaches
+    // CredentialManager.init() before passkey_authenticator.js has registered itself.
     (function() {
+      function loadFlutterBootstrap() {
+        var bootstrap = document.createElement('script');
+        bootstrap.src = 'flutter_bootstrap.js';
+        bootstrap.async = true;
+        document.body.appendChild(bootstrap);
+      }
       var script = document.createElement('script');
       script.src = 'assets/packages/credential_manager_web/web/passkey_authenticator.js';
+      script.onload = loadFlutterBootstrap;
       script.onerror = function() {
         // Try alternative path (flutter run dev server)
         var fallback = document.createElement('script');
         fallback.src = 'packages/credential_manager_web/web/passkey_authenticator.js';
+        fallback.onload = loadFlutterBootstrap;
         fallback.onerror = function() {
           // Final fallback
           var rootFallback = document.createElement('script');
           rootFallback.src = 'passkey_authenticator.js';
+          rootFallback.onload = loadFlutterBootstrap;
+          rootFallback.onerror = loadFlutterBootstrap;
           document.head.appendChild(rootFallback);
         };
         document.head.appendChild(fallback);
@@ -54,6 +66,5 @@
       document.head.appendChild(script);
     })();
   </script>
-  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Credential Manager plugin. Provides one-tap login functionality and stores credentials
   in the user's Google account on Android and in the Keychain on iOS.
 
-version: 4.0.0
+version: 4.1.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 
@@ -16,10 +16,10 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  credential_manager_platform_interface: ^2.0.8
-  credential_manager_android: ^3.0.1
-  credential_manager_ios: ^3.0.1
-  credential_manager_web: ^2.1.0
+  credential_manager_platform_interface: ^3.0.0
+  credential_manager_android: ^3.1.0
+  credential_manager_ios: ^3.1.0
+  credential_manager_web: ^2.2.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/credential_manager_android/CHANGELOG.md
+++ b/packages/credential_manager_android/CHANGELOG.md
@@ -1,4 +1,13 @@
-# 3.0.1
+# 3.1.0
+- Bumped `credential_manager_platform_interface` to `^3.0.0` (required — the previously-declared
+  `^2.0.8` resolves to a published version that predates the `nonce` parameter this package's
+  `saveGoogleCredential` override already relies on)
+- Security fix: the unified `getCredentials` Google option no longer generates an internal,
+  unverifiable nonce — it was never surfaced to the caller/backend for validation, so it provided
+  no real replay protection. Use `saveGoogleCredential(nonce: ...)` when nonce verification against
+  your backend is needed.
+
+## 3.0.1
 - Added Detekt static analysis configuration and CI checks; fixed all reported violations (replaced a wildcard import with explicit imports, renamed a file to match its top-level class, wrapped long lines)
 - No functional or API changes
 

--- a/packages/credential_manager_android/android/src/main/kotlin/com/smkwinner/cred_manager/credential_manager/CredentialManagerUtils.kt
+++ b/packages/credential_manager_android/android/src/main/kotlin/com/smkwinner/cred_manager/credential_manager/CredentialManagerUtils.kt
@@ -216,7 +216,10 @@ class CredentialManagerUtils {
                     addCredentialOption(
                         GetGoogleIdOption.Builder()
                             .setFilterByAuthorizedAccounts(false)
-                            .setNonce(generateSecureNonce())
+                            // No nonce here: this unified fetch path has no way to surface it to
+                            // the caller/backend for verification, so a generated-and-discarded
+                            // nonce would be misleading rather than real replay protection. Use
+                            // saveGoogleCredential(nonce: ...) when nonce verification is needed.
                             .setServerClientId(serverClientID)
                             .build()
                     )

--- a/packages/credential_manager_android/pubspec.yaml
+++ b/packages/credential_manager_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: credential_manager_android
 description: Android implementation of the credential_manager plugin using Jetpack Credential Manager API.
-version: 3.0.1
+version: 3.1.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 environment:
@@ -10,7 +10,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  credential_manager_platform_interface: ^2.0.8
+  credential_manager_platform_interface: ^3.0.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/credential_manager_ios/CHANGELOG.md
+++ b/packages/credential_manager_ios/CHANGELOG.md
@@ -1,4 +1,15 @@
-# 3.0.1
+# 3.1.0
+- Bumped `credential_manager_platform_interface` to `^3.0.0` (required — the previously-declared
+  `^2.0.8` resolves to a published version that predates the `nonce` parameter this package's
+  `saveGoogleCredential` override already relies on)
+- `savePasswordCredentials` and `saveGoogleCredential` now throw an explicit `CredentialException`
+  (code 103, "Not implemented") instead of silently reporting success without saving
+  (`savePasswordCredentials`) or surfacing an uncaught `MissingPluginException` from a
+  method-channel call with no native handler (`saveGoogleCredential`) — neither has a native Swift
+  implementation on iOS today
+- No breaking changes to the public Dart API
+
+## 3.0.1
 - Added SwiftLint configuration and CI checks; fixed all reported violations (force casts replaced with safe casts, wrapped long lines, aligned switch cases, extracted long functions)
 - No functional or API changes
 

--- a/packages/credential_manager_ios/lib/src/credential_manager_ios.dart
+++ b/packages/credential_manager_ios/lib/src/credential_manager_ios.dart
@@ -53,15 +53,13 @@ class CredentialManagerIos extends CredentialManagerPlatform {
 
   @override
   Future<void> savePasswordCredentials(PasswordCredential credential) async {
-    try {
-      // Nothing on ios simply return
-      return;
-    } on PlatformException catch (e) {
-      throw PlatformExceptionHandler.handlePlatformException(
-        e,
-        CredentialType.passwordCredentials,
-      );
-    }
+    // There is no native Swift handler for this method (only passkeys and init are wired up on
+    // iOS today), so fail explicitly rather than silently reporting success without saving.
+    throw CredentialException(
+      code: 103,
+      message: "Not implemented",
+      details: "savePasswordCredentials is not supported on iOS",
+    );
   }
 
   @override
@@ -100,26 +98,14 @@ class CredentialManagerIos extends CredentialManagerPlatform {
 
   @override
   Future<GoogleIdTokenCredential?> saveGoogleCredential(bool useButtonFlow, {String? nonce}) async {
-    try {
-      final res = await methodChannel.invokeMethod<Map<Object?, Object?>>(
-        'save_google_credential',
-        {"useButtonFlow": useButtonFlow, "nonce": nonce},
-      );
-
-      if (res == null) {
-        throw CredentialException(
-          code: 505,
-          message: "Google credential decode error",
-          details: "Null response received",
-        );
-      }
-      return GoogleIdTokenCredential.fromJson(jsonDecode(jsonEncode(res)));
-    } on PlatformException catch (e) {
-      throw PlatformExceptionHandler.handlePlatformException(
-        e,
-        CredentialType.googleIdTokenCredentials,
-      );
-    }
+    // There is no native Swift handler for "save_google_credential" (CredentialManagerPlugin.handle
+    // only dispatches passkey/init methods), so calling through would surface an unhandled
+    // MissingPluginException. Fail explicitly instead.
+    throw CredentialException(
+      code: 103,
+      message: "Not implemented",
+      details: "saveGoogleCredential is not supported on iOS",
+    );
   }
 
   @override

--- a/packages/credential_manager_ios/pubspec.yaml
+++ b/packages/credential_manager_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: credential_manager_ios
 description: iOS implementation of the credential_manager plugin using Keychain and Autofill.
-version: 3.0.1
+version: 3.1.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose$
 
@@ -13,7 +13,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  credential_manager_platform_interface: ^2.0.8
+  credential_manager_platform_interface: ^3.0.0
   cbor: ^6.3.5
 
 dev_dependencies:

--- a/packages/credential_manager_platform_interface/CHANGELOG.md
+++ b/packages/credential_manager_platform_interface/CHANGELOG.md
@@ -1,4 +1,18 @@
-# 2.0.8
+# 3.0.0
+- **Breaking:** `CredentialManagerPlatform.saveGoogleCredential` gains an optional named `{String?
+  nonce}` parameter. This was actually added in a prior commit without a version bump — the
+  package published as `2.0.8` on pub.dev predates this change and does not have `nonce`, which
+  broke `flutter pub get`/analysis for anyone resolving `credential_manager_platform_interface` from
+  pub.dev (this repo's own melos workspace masked it locally via path-based resolution). Publishing
+  this as a new major version is a correction, not new API surface.
+- Any external `CredentialManagerPlatform` implementation overriding `saveGoogleCredential(bool
+  useButtonFlow)` without the `nonce` parameter will fail to compile against this version — add
+  `{String? nonce}` to your override (Dart requires overrides to declare every named parameter of
+  the overridden method, even optional ones).
+- No other functional changes; remaining diffs since `2.0.8` are formatting-only (120-column
+  reformat).
+
+## 2.0.8
 - Added `isGmsAvailable` to platform interface
 - Handle `exception code 209` for Google Play Services not available
 - on Android, Google account is not logged in, the plugin will  launch Google Sign-In flow.

--- a/packages/credential_manager_platform_interface/pubspec.yaml
+++ b/packages/credential_manager_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: credential_manager_platform_interface
 description: A common platform interface for the credential_manager plugin. This package allows platform-specific implementations of credential_manager to share the same interface.
 
-version: 2.0.8
+version: 3.0.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 

--- a/packages/credential_manager_web/CHANGELOG.md
+++ b/packages/credential_manager_web/CHANGELOG.md
@@ -1,4 +1,19 @@
-# 2.1.0
+# 2.2.0
+- Bumped `credential_manager_platform_interface` to `^3.0.0` (required — the previously-declared
+  `^2.0.8` resolves to a published version that predates the `nonce` parameter this package's
+  `saveGoogleCredential` override already relies on)
+- Fixed `getPasswordCredentials` requesting a WebAuthn assertion (`publicKey` options) instead of a
+  stored password credential (`password: true`) — it could never succeed at its stated purpose
+- `cancelCurrentAuthenticatorOperation` now cancels an in-flight Google Identity Services flow too
+  (previously a no-op for anything but WebAuthn, leaving a pending `saveGoogleCredential` unresolved)
+- Added a defensive 30s timeout to the passive Google One Tap prompt path, since FedCM can leave the
+  request pending indefinitely without a display/skip notification
+- Renamed the internal `_googleClientId` parameter on the JS `initialize` method to `googleClientId`
+  (was misleadingly underscore-prefixed despite being used) and clarified its documentation
+- Raised the minimum `flutter` SDK constraint to `3.24.0` (first release paired with Dart 3.5,
+  matching this package's existing `sdk: '>=3.5.0'` constraint)
+
+## 2.1.0
 
 - Fixed the `<script>` tag path documented in the README, Google Sign-In setup guide, and example
   app's `web/index.html`: `flutter build web` places plugin `web/` assets under

--- a/packages/credential_manager_web/GOOGLE_SIGNIN_SETUP.md
+++ b/packages/credential_manager_web/GOOGLE_SIGNIN_SETUP.md
@@ -95,7 +95,7 @@ final credentials = await credentialManager.getCredentials(
 
 ## Response Format
 
-`saveGoogleCredential`/`getCredentials` return a `GoogleIdTokenCredential`, matching Android/iOS:
+`saveGoogleCredential` returns a `GoogleIdTokenCredential` directly, matching Android/iOS:
 
 ```dart
 GoogleIdTokenCredential(
@@ -108,6 +108,9 @@ GoogleIdTokenCredential(
   profilePictureUri: Uri.parse('https://...'),
 )
 ```
+
+`getCredentials` returns a `Credentials` wrapper instead — read the same data via
+`credentials.googleIdTokenCredential`.
 
 ## Security Considerations
 

--- a/packages/credential_manager_web/README.md
+++ b/packages/credential_manager_web/README.md
@@ -64,7 +64,7 @@ This package uses:
 - `@github/webauthn-json` library for WebAuthn operations
 - Native `navigator.credentials` API for password credentials
 - Google Identity Services (`https://accounts.google.com/gsi/client`), lazily loaded, for Google Sign-In
-- Dart FFI (`dart:js_interop`) for JavaScript interop
+- Dart JavaScript interop (`dart:js_interop`)
 
 ## Documentation
 
@@ -77,5 +77,5 @@ This package uses:
 
 ## License
 
-See the [LICENSE](../LICENSE) file for details.
+See the [LICENSE](LICENSE) file for details.
 

--- a/packages/credential_manager_web/lib/javascript/src/index.ts
+++ b/packages/credential_manager_web/lib/javascript/src/index.ts
@@ -181,8 +181,9 @@ class CredentialManagerWeb {
    * Cancel the current authenticator operation
    */
   static cancelCurrentAuthenticatorOperation(): void {
-    // WebAuthn doesn't provide a direct cancel method
-    // This is a placeholder for any cleanup needed
+    // WebAuthn doesn't provide a direct cancel method.
+    // Cancel any in-flight Google Identity Services flow.
+    window.google?.accounts?.id?.cancel();
   }
 
   /**
@@ -237,12 +238,13 @@ class CredentialManagerWeb {
   /**
    * Initialize with preferences
    * @param preferImmediatelyAvailableCredentials - Whether to prefer immediately available credentials
-   * @param _googleClientId - Google client ID (optional, reserved for future use)
+   * @param googleClientId - Google Web OAuth client ID used for Google Identity Services
+   *   initialization (required for saveGoogleCredential; pass null if Google Sign-In isn't used)
    * @returns Promise resolving to success message
    */
   static async initialize(
     preferImmediatelyAvailableCredentials: boolean,
-    _googleClientId: string | null
+    googleClientId: string | null
   ): Promise<string> {
     // Check if Credential Management API is available
     if (!navigator.credentials) {
@@ -251,7 +253,7 @@ class CredentialManagerWeb {
 
     // Store initialization parameters
     CredentialManagerWeb.preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials;
-    CredentialManagerWeb._googleClientId = _googleClientId;
+    CredentialManagerWeb._googleClientId = googleClientId;
     return 'Initialization successful';
   }
 
@@ -290,16 +292,14 @@ class CredentialManagerWeb {
         throw new Error('Credential Management API is not supported');
       }
 
-      const options: CredentialRequestOptions = {
-        publicKey: {
-          challenge: new Uint8Array(32),
-          rpId: CredentialManagerWeb._googleClientId || 'localhost',
-          userVerification: 'required', 
-        },
-        mediation: (CredentialManagerWeb.preferImmediatelyAvailableCredentials 
-          ? 'silent' 
+      // TypeScript's lib.dom.d.ts doesn't model the Credential Management API's `password`
+      // option on CredentialRequestOptions, so this needs an escape hatch to `any`.
+      const options = {
+        password: true,
+        mediation: (CredentialManagerWeb.preferImmediatelyAvailableCredentials
+          ? 'silent'
           : 'optional') as CredentialMediationRequirement
-      };
+      } as any;
 
       const credential = await navigator.credentials.get(options);
 
@@ -419,6 +419,7 @@ class CredentialManagerWeb {
 
     return new Promise<string | null>((resolve, reject) => {
       let settled = false;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
       google.accounts.id.initialize({
         client_id: clientId,
@@ -430,6 +431,7 @@ class CredentialManagerWeb {
         callback: (response: GsiCredentialResponse) => {
           if (settled) return;
           settled = true;
+          if (timeoutId !== undefined) clearTimeout(timeoutId);
           try {
             resolve(JSON.stringify(CredentialManagerWeb._decodeGoogleIdToken(response.credential)));
           } catch (error) {
@@ -455,10 +457,20 @@ class CredentialManagerWeb {
         }
         clickable.click();
       } else {
+        // Under FedCM, isNotDisplayed()/getNotDisplayedReason() are deprecated and the browser
+        // (not this callback) controls prompt visibility, so a skip/no-display doesn't always
+        // reach this notification. Fall back to a timeout so the Promise can't hang forever.
+        timeoutId = setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          reject(new Error('Google One Tap timed out waiting for a prompt response'));
+        }, 30000);
+
         google.accounts.id.prompt((notification: GsiPromptMomentNotification) => {
           if (settled) return;
           if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
             settled = true;
+            clearTimeout(timeoutId);
             const reason = notification.isNotDisplayed()
               ? notification.getNotDisplayedReason()
               : notification.getSkippedReason();

--- a/packages/credential_manager_web/pubspec.yaml
+++ b/packages/credential_manager_web/pubspec.yaml
@@ -1,11 +1,11 @@
 name: credential_manager_web
 description: Web implementation of the credential_manager plugin using Web Authentication API (WebAuthn) and Credential Management API.
-version: 2.1.0
+version: 2.2.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 environment:
   sdk: '>=3.5.0 <4.0.0'
-  flutter: '>=3.3.0'
+  flutter: '>=3.24.0'
 
 resolution: workspace
 
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  credential_manager_platform_interface: ^2.0.8
+  credential_manager_platform_interface: ^3.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/credential_manager_web/web/index.d.ts
+++ b/packages/credential_manager_web/web/index.d.ts
@@ -92,10 +92,11 @@ declare class CredentialManagerWeb {
     /**
      * Initialize with preferences
      * @param preferImmediatelyAvailableCredentials - Whether to prefer immediately available credentials
-     * @param _googleClientId - Google client ID (optional, reserved for future use)
+     * @param googleClientId - Google Web OAuth client ID used for Google Identity Services
+     *   initialization (required for saveGoogleCredential; pass null if Google Sign-In isn't used)
      * @returns Promise resolving to success message
      */
-    static initialize(preferImmediatelyAvailableCredentials: boolean, _googleClientId: string | null): Promise<string>;
+    static initialize(preferImmediatelyAvailableCredentials: boolean, googleClientId: string | null): Promise<string>;
     /**
      * Save password credentials
      * @param credentialData - JSON string containing credential data

--- a/packages/credential_manager_web/web/passkey_authenticator.js
+++ b/packages/credential_manager_web/web/passkey_authenticator.js
@@ -329,8 +329,10 @@ var CredentialManagerWeb = (function () {
        * Cancel the current authenticator operation
        */
       static cancelCurrentAuthenticatorOperation() {
-          // WebAuthn doesn't provide a direct cancel method
-          // This is a placeholder for any cleanup needed
+          var _a, _b, _c;
+          // WebAuthn doesn't provide a direct cancel method.
+          // Cancel any in-flight Google Identity Services flow.
+          (_c = (_b = (_a = window.google) === null || _a === void 0 ? void 0 : _a.accounts) === null || _b === void 0 ? void 0 : _b.id) === null || _c === void 0 ? void 0 : _c.cancel();
       }
       /**
        * Check if user-verifying platform authenticator is available
@@ -382,17 +384,18 @@ var CredentialManagerWeb = (function () {
       /**
        * Initialize with preferences
        * @param preferImmediatelyAvailableCredentials - Whether to prefer immediately available credentials
-       * @param _googleClientId - Google client ID (optional, reserved for future use)
+       * @param googleClientId - Google Web OAuth client ID used for Google Identity Services
+       *   initialization (required for saveGoogleCredential; pass null if Google Sign-In isn't used)
        * @returns Promise resolving to success message
        */
-      static async initialize(preferImmediatelyAvailableCredentials, _googleClientId) {
+      static async initialize(preferImmediatelyAvailableCredentials, googleClientId) {
           // Check if Credential Management API is available
           if (!navigator.credentials) {
               throw new Error('Credential Management API is not supported in this browser');
           }
           // Store initialization parameters
           CredentialManagerWeb.preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials;
-          CredentialManagerWeb._googleClientId = _googleClientId;
+          CredentialManagerWeb._googleClientId = googleClientId;
           return 'Initialization successful';
       }
       /**
@@ -427,12 +430,10 @@ var CredentialManagerWeb = (function () {
               if (!navigator.credentials || !navigator.credentials.get) {
                   throw new Error('Credential Management API is not supported');
               }
+              // TypeScript's lib.dom.d.ts doesn't model the Credential Management API's `password`
+              // option on CredentialRequestOptions, so this needs an escape hatch to `any`.
               const options = {
-                  publicKey: {
-                      challenge: new Uint8Array(32),
-                      rpId: CredentialManagerWeb._googleClientId || 'localhost',
-                      userVerification: 'required',
-                  },
+                  password: true,
                   mediation: (CredentialManagerWeb.preferImmediatelyAvailableCredentials
                       ? 'silent'
                       : 'optional')
@@ -541,6 +542,7 @@ var CredentialManagerWeb = (function () {
           const effectiveNonce = nonce || CredentialManagerWeb._generateSecureNonce();
           return new Promise((resolve, reject) => {
               let settled = false;
+              let timeoutId;
               google.accounts.id.initialize({
                   client_id: clientId,
                   nonce: effectiveNonce,
@@ -552,6 +554,8 @@ var CredentialManagerWeb = (function () {
                       if (settled)
                           return;
                       settled = true;
+                      if (timeoutId !== undefined)
+                          clearTimeout(timeoutId);
                       try {
                           resolve(JSON.stringify(CredentialManagerWeb._decodeGoogleIdToken(response.credential)));
                       }
@@ -577,11 +581,21 @@ var CredentialManagerWeb = (function () {
                   clickable.click();
               }
               else {
+                  // Under FedCM, isNotDisplayed()/getNotDisplayedReason() are deprecated and the browser
+                  // (not this callback) controls prompt visibility, so a skip/no-display doesn't always
+                  // reach this notification. Fall back to a timeout so the Promise can't hang forever.
+                  timeoutId = setTimeout(() => {
+                      if (settled)
+                          return;
+                      settled = true;
+                      reject(new Error('Google One Tap timed out waiting for a prompt response'));
+                  }, 30000);
                   google.accounts.id.prompt((notification) => {
                       if (settled)
                           return;
                       if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
                           settled = true;
+                          clearTimeout(timeoutId);
                           const reason = notification.isNotDisplayed()
                               ? notification.getNotDisplayedReason()
                               : notification.getSkippedReason();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -518,4 +518,4 @@ packages:
     version: "2.2.4"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.24.0"


### PR DESCRIPTION
## Summary
Resolves 22 CodeRabbit findings from PR #79 (verified against current code, not applied blindly — several were already resolved by later commits, and a couple of the bot's literal suggestions would have introduced new bugs given the actual native state, so those were adapted):

- **credential_manager_web (JS)**: `getPasswordCredentials` used WebAuthn options instead of `password: true` (critical — could never succeed); `cancelCurrentAuthenticatorOperation` was a no-op for in-flight Google flows; added a defensive timeout to the passive Google One Tap path (FedCM can leave it pending forever); renamed the misleading `_googleClientId` param; fixed the Flutter SDK constraint mismatch.
- **credential_manager_ios**: `savePasswordCredentials`/`saveGoogleCredential` now throw an explicit `CredentialException` instead of silently succeeding without saving, or surfacing an uncaught `MissingPluginException` — neither has a native Swift handler today.
- **credential_manager_android**: removed a Google-login nonce that was generated internally and never surfaced to the caller/backend — it provided no real replay protection.
- **example app**: fixed a script-load race that could let Flutter boot before `passkey_authenticator.js` registered itself; iOS logout skip (guarded, since there's no native handler yet); broadened `init()` exception handling; `conditionalUI` was enabled on all platforms despite being iOS-only.
- **Docs**: license link, FFI→JS-interop wording, Web OAuth client type clarity, response-type docs, iOS-unsupported docs, `googleClientId` required-for-Web note.
- **CI**: added `contents: read` + `persist-credentials: false` to the flagged job (the shell-injection finding was already resolved by an earlier refactor that dropped the `pull_request` trigger entirely).

### Critical fix this surfaced
`credential_manager` 4.0.0 depends on `credential_manager_platform_interface: ^2.0.8`, but the `nonce` parameter `saveGoogleCredential` relies on was added to that file without ever bumping its version — the actual pub.dev `2.0.8` release predates it, breaking `flutter pub get`/analysis for anyone resolving from pub.dev (this repo's melos/pub workspace masked it locally, since workspace resolution always uses local sibling paths regardless of declared constraints). This is why `credential_manager` 4.0.0 was retracted.

Version bumps (dependency order): `credential_manager_platform_interface` 2.0.8→3.0.0 (breaking — new named param, which Dart requires overrides to declare), `credential_manager_android` 3.0.1→3.1.0, `credential_manager_ios` 3.0.1→3.1.0, `credential_manager_web` 2.1.0→2.2.0, `credential_manager` 4.0.0→4.1.0.

## Test plan
- [x] `make bootstrap` / `make check` (format-check + analyze + swiftlint + detekt) — all clean
- [x] Rebuilt the JS bundle from TS source (`npm run build` in `lib/javascript/`) and verified the fixes landed in the compiled `passkey_authenticator.js`
- [x] Diffed the real pub.dev-published `credential_manager_platform_interface@2.0.8` tarball against local source to confirm `nonce` is the only functional difference before deciding the version bump
- [x] `flutter pub publish --dry-run` for all 5 packages — clean aside from expected "uncommitted changes" warnings