### PR TITLE
fix: keep PasskeyService alive until FlutterResult fires (#92)

### DIFF
--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-# 4.1.0
+# 4.2.0
+- Bumped `credential_manager_ios` to `^3.2.0`, fixing #92: passkey registration/authentication
+  could silently hang forever on iOS (no exception, no error code) due to a native retain-cycle
+  bug introduced in `credential_manager_ios` 3.0.1 — see its own CHANGELOG for details
+- No breaking changes to this package's own public Dart API
+
+## 4.1.0
 - **Fixes a critical issue in 4.0.0**: that release depended on `credential_manager_platform_interface:
   ^2.0.8`, but the actual pub.dev `2.0.8` release predates the `nonce` parameter this package's
   Google Sign-In call relies on, breaking `flutter pub get`/analysis for anyone resolving from

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Credential Manager plugin. Provides one-tap login functionality and stores credentials
   in the user's Google account on Android and in the Keychain on iOS.
 
-version: 4.1.0
+version: 4.2.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 
@@ -18,7 +18,7 @@ dependencies:
     sdk: flutter
   credential_manager_platform_interface: ^3.0.0
   credential_manager_android: ^3.1.0
-  credential_manager_ios: ^3.1.0
+  credential_manager_ios: ^3.2.0
   credential_manager_web: ^2.2.0
 
 dev_dependencies:

--- a/packages/credential_manager_ios/CHANGELOG.md
+++ b/packages/credential_manager_ios/CHANGELOG.md
@@ -1,4 +1,17 @@
-# 3.1.0
+# 3.2.0
+- **Fixes #92: passkey registration/authentication silently hangs since 3.0.1.** `savePassKeyCredentials`
+  and `getPasskeyCredentials` created `PasskeyService` as a local variable with no strong reference
+  held anywhere; once the enclosing method returned, it deallocated immediately. Since
+  `ASAuthorizationController`'s delegate and presentation-context-provider are held weakly, this
+  silently dropped the completion callback (success or failure) and the Dart `Future` never
+  resolved — no exception, no error code, forever. `[weak self]` in `PasskeyService`'s own
+  completion closures (added in 3.0.1's SwiftLint cleanup) is what exposed this: previously an
+  unintentional retain cycle kept the object graph alive long enough to mask the bug.
+- `CredentialManagerPlugin` now holds a strong `inFlightPasskeyService` reference for the duration
+  of each passkey call, cleared once its `FlutterResult` fires.
+- No breaking changes to the public Dart API
+
+## 3.1.0
 - Bumped `credential_manager_platform_interface` to `^3.0.0` (required — the previously-declared
   `^2.0.8` resolves to a published version that predates the `nonce` parameter this package's
   `saveGoogleCredential` override already relies on)

--- a/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/CredentialManager.swift
+++ b/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/CredentialManager.swift
@@ -8,6 +8,12 @@ protocol Cancellable {
 
 public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     var preferImmediatelyAvailableCredentials: Bool = false
+    // Keeps the in-flight PasskeyService alive until its FlutterResult fires. Without this,
+    // the local `PasskeyService` in savePassKeyCredentials/getPasskeyCredentials below is the
+    // only strong reference to it; it deallocates as soon as that method returns, and since
+    // ASAuthorizationController's delegate/presentationContextProvider are weak, the completion
+    // callback (success or failure) is silently dropped and the Dart Future hangs forever.
+    private var inFlightPasskeyService: AnyObject?
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "credential_manager", binaryMessenger: registrar.messenger())
@@ -31,8 +37,12 @@ public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     }
     private func savePassKeyCredentials(call: FlutterMethodCall, result: @escaping FlutterResult) {
         if #available(iOS 16.0, *) {
-            let passkeyService: PasskeyService = PasskeyService()
-            passkeyService.registerPasskeyCredentials(call: call, result: result)
+            let passkeyService = PasskeyService()
+            inFlightPasskeyService = passkeyService
+            passkeyService.registerPasskeyCredentials(call: call) { [weak self] res in
+                self?.inFlightPasskeyService = nil
+                result(res)
+            }
         } else {
             result(FlutterError(
                 code: String(describing: CustomErrors.unsupportedPlatform),
@@ -43,10 +53,14 @@ public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     }
     private func getPasskeyCredentials(call: FlutterMethodCall, result: @escaping FlutterResult) {
         if #available(iOS 16.0, *) {
-            let passkeyService: PasskeyService = PasskeyService()
+            let passkeyService = PasskeyService()
+            inFlightPasskeyService = passkeyService
             passkeyService.getPasskeyCredentials(
                 call: call,
-                result: result,
+                result: { [weak self] res in
+                    self?.inFlightPasskeyService = nil
+                    result(res)
+                },
                 preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
             )
         } else {

--- a/packages/credential_manager_ios/pubspec.yaml
+++ b/packages/credential_manager_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: credential_manager_ios
 description: iOS implementation of the credential_manager plugin using Keychain and Autofill.
-version: 3.1.0
+version: 3.2.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose$
 


### PR DESCRIPTION
## Summary
- Fixes #92: on iOS, `savePasskeyCredentials()`/`getCredentials(passKeyOption:)` could hang forever (no exception, no error code) since `credential_manager_ios` 3.0.1. `PasskeyService` was created as a local variable with no strong reference; once the enclosing plugin method returned, it deallocated, and since `ASAuthorizationController`'s delegate/presentationContextProvider are weak, the completion callback was silently dropped.
- `CredentialManagerPlugin` now holds a strong `inFlightPasskeyService` reference for the duration of each passkey call, cleared once its `FlutterResult` fires — preserving the `[weak self]` lint fix from #75 instead of reintroducing the old retain-cycle-as-a-feature bug.
- Bumps `credential_manager_ios` 3.1.0 → 3.2.0 and `credential_manager` 4.1.0 → 4.2.0 (bug fix → minor bump per this repo's convention).

## Test plan
- [x] `make check` (format, analyze, SwiftLint, Detekt) passes cleanly
- [x] Reproduced the hang pre-fix on iOS Simulator: `savePasskeyCredentials` left the UI stuck on a loading spinner indefinitely with no error surfaced
- [x] Confirmed post-fix: the same call now returns/throws promptly (spinner clears, `FlutterError` surfaces) instead of hanging — verified against a local `apple-app-site-association` setup since AASA verification itself needs a paid Apple Developer account, which is orthogonal to this bug
- [ ] Reporter (`@houzx2581396`) to confirm fix resolves their original repro on physical device with real AASA setup