### PR TITLE
chore: promote develop to main

### DIFF
--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -21,6 +21,27 @@ credential_manager_android   credential_manager_ios   (each depends on platform_
 
 Package locations: `packages/<name>/pubspec.yaml` + `packages/<name>/CHANGELOG.md`.
 
+## Fast path: `packages/scripts/auto-release.sh`
+
+For a routine release with no unusual judgment calls, `packages/scripts/auto-release.sh` automates
+Steps 1–5 below: it diffs each package's source paths against `origin/main`, asks `claude -p`
+(headless, default model `haiku`) to classify each changed package as `minor`/`major` per this
+repo's convention, bumps `pubspec.yaml` + drafts a `CHANGELOG.md` entry from commit subjects,
+propagates the bump to dependents, runs `make check`, and opens a PR against `develop`.
+
+```
+packages/scripts/auto-release.sh --dry-run   # show the plan, change nothing
+packages/scripts/auto-release.sh             # apply it and open the PR (prompts for confirmation)
+```
+
+It deliberately stops there — it never merges the PR, promotes `develop` → `main`, or runs
+`flutter pub publish` (dry-run or real). Continue from Step 6 onward manually once the PR looks
+right (the drafted CHANGELOG entries are a starting point from commit subjects, not final prose —
+review and edit them before merging). Skip this script and do Steps 1–5 by hand for anything with
+real judgment calls (e.g. this file already predates the `credential_manager_web` package being
+added to the dependency graph — see the live `pubspec.yaml` files as ground truth over this
+diagram if they disagree).
+
 ## Step 1 — Determine version bump type
 
 Ask the user (or infer from the change) what kind of change this is, per this repo's convention:

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -29,7 +29,7 @@ Steps 1–5 below: it diffs each package's source paths against `origin/main`, a
 repo's convention, bumps `pubspec.yaml` + drafts a `CHANGELOG.md` entry from commit subjects,
 propagates the bump to dependents, runs `make check`, and opens a PR against `develop`.
 
-```
+```bash
 packages/scripts/auto-release.sh --dry-run   # show the plan, change nothing
 packages/scripts/auto-release.sh             # apply it and open the PR (prompts for confirmation)
 ```

--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-# 4.1.0
+# 4.2.0
+- Bumped `credential_manager_ios` to `^3.2.0`, fixing #92: passkey registration/authentication
+  could silently hang forever on iOS (no exception, no error code) due to a native retain-cycle
+  bug introduced in `credential_manager_ios` 3.0.1 — see its own CHANGELOG for details
+- No breaking changes to this package's own public Dart API
+
+## 4.1.0
 - **Fixes a critical issue in 4.0.0**: that release depended on `credential_manager_platform_interface:
   ^2.0.8`, but the actual pub.dev `2.0.8` release predates the `nonce` parameter this package's
   Google Sign-In call relies on, breaking `flutter pub get`/analysis for anyone resolving from

--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 ## 4.2.0
 - Bumped `credential_manager_ios` to `^3.2.0`, fixing #92: passkey registration/authentication
-  could silently hang forever on iOS (no exception, no error code) due to a native retain-cycle
-  bug introduced in `credential_manager_ios` 3.0.1 — see its own CHANGELOG for details
+  could silently hang forever on iOS (no exception, no error code) because `PasskeyService` was
+  deallocated before authorization completed in `credential_manager_ios` 3.0.1 — see its own
+  CHANGELOG for details
 - No breaking changes to this package's own public Dart API
 
 ## 4.1.0

--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-# 4.2.0
+# 4.3.0
+- Republishes 4.2.0's contents with a clean `example/` directory. 4.2.0's published archive
+  accidentally included 4 locally-modified-but-uncommitted `example/ios/` files (Xcode-project
+  migration churn from local tooling, not a deliberate change) instead of what's committed to
+  `main` — cosmetic only (demo app scaffolding, not `lib/` or native plugin source), but
+  corrected here for a clean package listing. No functional or API changes.
+
+## 4.2.0
 - Bumped `credential_manager_ios` to `^3.2.0`, fixing #92: passkey registration/authentication
   could silently hang forever on iOS (no exception, no error code) because `PasskeyService` was
   deallocated before authorization completed in `credential_manager_ios` 3.0.1 — see its own

--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 # 4.2.0
 - Bumped `credential_manager_ios` to `^3.2.0`, fixing #92: passkey registration/authentication
-  could silently hang forever on iOS (no exception, no error code) due to a native retain-cycle
-  bug introduced in `credential_manager_ios` 3.0.1 — see its own CHANGELOG for details
+  could silently hang forever on iOS (no exception, no error code) because `PasskeyService` was
+  deallocated before authorization completed in `credential_manager_ios` 3.0.1 — see its own
+  CHANGELOG for details
 - No breaking changes to this package's own public Dart API
 
 ## 4.1.0

--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-# 4.2.0
+# 4.3.0
+- Bumped `credential_manager_android` to `^3.2.0` (migrated to Flutter's built-in Kotlin support,
+  fixing a "will cause build failures in future versions of Flutter" warning on Flutter 3.44+ —
+  see its own CHANGELOG for details)
+- No breaking changes to this package's own public Dart API
+
+## 4.2.0
 - Bumped `credential_manager_ios` to `^3.2.0`, fixing #92: passkey registration/authentication
   could silently hang forever on iOS (no exception, no error code) due to a native retain-cycle
   bug introduced in `credential_manager_ios` 3.0.1 — see its own CHANGELOG for details

--- a/packages/credential_manager/example/android/app/build.gradle
+++ b/packages/credential_manager/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -42,10 +41,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
     }
 
     sourceSets {

--- a/packages/credential_manager/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/credential_manager/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip

--- a/packages/credential_manager/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/credential_manager/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip

--- a/packages/credential_manager/example/android/settings.gradle
+++ b/packages/credential_manager/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.11.1" apply false
+    id "com.android.application" version "9.0.1" apply false
 }
 
 include ":app"

--- a/packages/credential_manager/example/android/settings.gradle
+++ b/packages/credential_manager/example/android/settings.gradle
@@ -19,7 +19,6 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.11.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
 }
 
 include ":app"

--- a/packages/credential_manager/example/android/settings.gradle
+++ b/packages/credential_manager/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.0.20" apply false
 }
 

--- a/packages/credential_manager/example/android/settings.gradle
+++ b/packages/credential_manager/example/android/settings.gradle
@@ -19,6 +19,10 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "9.0.1" apply false
+    // Not applied (built-in Kotlin, via AGP 9, compiles Kotlin sources without this plugin) -
+    // declared only so Flutter's built-in-Kotlin support resolves this version instead of its
+    // own default, which silences "Kotlin version will soon be dropped" warnings.
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Credential Manager plugin. Provides one-tap login functionality and stores credentials
   in the user's Google account on Android and in the Keychain on iOS.
 
-version: 4.1.0
+version: 4.2.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 
@@ -18,7 +18,7 @@ dependencies:
     sdk: flutter
   credential_manager_platform_interface: ^3.0.0
   credential_manager_android: ^3.1.0
-  credential_manager_ios: ^3.1.0
+  credential_manager_ios: ^3.2.0
   credential_manager_web: ^2.2.0
 
 dev_dependencies:

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Credential Manager plugin. Provides one-tap login functionality and stores credentials
   in the user's Google account on Android and in the Keychain on iOS.
 
-version: 4.2.0
+version: 4.3.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   credential_manager_platform_interface: ^3.0.0
-  credential_manager_android: ^3.1.0
+  credential_manager_android: ^3.2.0
   credential_manager_ios: ^3.2.0
   credential_manager_web: ^2.2.0
 

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Credential Manager plugin. Provides one-tap login functionality and stores credentials
   in the user's Google account on Android and in the Keychain on iOS.
 
-version: 4.2.0
+version: 4.3.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   credential_manager_platform_interface: ^3.0.0
-  credential_manager_android: ^3.1.0
+  credential_manager_android: ^3.2.0
   credential_manager_ios: ^3.2.0
   credential_manager_web: ^2.2.0
 

--- a/packages/credential_manager_android/CHANGELOG.md
+++ b/packages/credential_manager_android/CHANGELOG.md
@@ -1,4 +1,12 @@
-# 3.1.0
+# 3.2.0
+- Migrated to Flutter's built-in Kotlin support: removed the explicit `kotlin-android` plugin
+  application and `ext.kotlin_version`/`kotlin-gradle-plugin` classpath from `android/build.gradle`.
+  Fixes the "applies the Kotlin Gradle Plugin, which will cause build failures in future versions
+  of Flutter" warning consuming apps saw on Flutter 3.44+; see
+  https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+- No functional or API changes
+
+## 3.1.0
 - Bumped `credential_manager_platform_interface` to `^3.0.0` (required — the previously-declared
   `^2.0.8` resolves to a published version that predates the `nonce` parameter this package's
   `saveGoogleCredential` override already relies on)

--- a/packages/credential_manager_android/android/build.gradle
+++ b/packages/credential_manager_android/android/build.gradle
@@ -2,7 +2,6 @@ group 'com.smkwinner.cred_manager.credential_manager'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.22'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.11.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.7'
     }
 }
@@ -23,7 +21,6 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 apply plugin: 'io.gitlab.arturbosch.detekt'
 
 detekt {
@@ -46,10 +43,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
     }
 
     sourceSets {

--- a/packages/credential_manager_android/android/build.gradle
+++ b/packages/credential_manager_android/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.1'
+        classpath 'com.android.tools.build:gradle:9.0.1'
         classpath 'io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.7'
     }
 }

--- a/packages/credential_manager_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/credential_manager_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/credential_manager_android/pubspec.yaml
+++ b/packages/credential_manager_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: credential_manager_android
 description: Android implementation of the credential_manager plugin using Jetpack Credential Manager API.
-version: 3.1.0
+version: 3.2.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 environment:

--- a/packages/credential_manager_ios/CHANGELOG.md
+++ b/packages/credential_manager_ios/CHANGELOG.md
@@ -1,4 +1,17 @@
-# 3.1.0
+# 3.2.0
+- **Fixes #92: passkey registration/authentication silently hangs since 3.0.1.** `savePassKeyCredentials`
+  and `getPasskeyCredentials` created `PasskeyService` as a local variable with no strong reference
+  held anywhere; once the enclosing method returned, it deallocated immediately. Since
+  `ASAuthorizationController`'s delegate and presentation-context-provider are held weakly, this
+  silently dropped the completion callback (success or failure) and the Dart `Future` never
+  resolved — no exception, no error code, forever. `[weak self]` in `PasskeyService`'s own
+  completion closures (added in 3.0.1's SwiftLint cleanup) is what exposed this: previously an
+  unintentional retain cycle kept the object graph alive long enough to mask the bug.
+- `CredentialManagerPlugin` now holds a strong `inFlightPasskeyService` reference for the duration
+  of each passkey call, cleared once its `FlutterResult` fires.
+- No breaking changes to the public Dart API
+
+## 3.1.0
 - Bumped `credential_manager_platform_interface` to `^3.0.0` (required — the previously-declared
   `^2.0.8` resolves to a published version that predates the `nonce` parameter this package's
   `saveGoogleCredential` override already relies on)

--- a/packages/credential_manager_ios/CHANGELOG.md
+++ b/packages/credential_manager_ios/CHANGELOG.md
@@ -7,8 +7,10 @@
   resolved — no exception, no error code, forever. `[weak self]` in `PasskeyService`'s own
   completion closures (added in 3.0.1's SwiftLint cleanup) is what exposed this: previously an
   unintentional retain cycle kept the object graph alive long enough to mask the bug.
-- `CredentialManagerPlugin` now holds a strong `inFlightPasskeyService` reference for the duration
-  of each passkey call, cleared once its `FlutterResult` fires.
+- `CredentialManagerPlugin` now holds a strong reference to each in-flight `PasskeyService` for the
+  duration of its call, removed once its own `FlutterResult` fires. Uses a collection rather than a
+  single slot, so overlapping passkey calls (e.g. register and get in flight together) don't cause
+  one call's `PasskeyService` to release another's out from under its still-active authorization.
 - No breaking changes to the public Dart API
 
 ## 3.1.0

--- a/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/CredentialManager.swift
+++ b/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/CredentialManager.swift
@@ -8,6 +8,12 @@ protocol Cancellable {
 
 public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     var preferImmediatelyAvailableCredentials: Bool = false
+    // Keeps the in-flight PasskeyService alive until its FlutterResult fires. Without this,
+    // the local `PasskeyService` in savePassKeyCredentials/getPasskeyCredentials below is the
+    // only strong reference to it; it deallocates as soon as that method returns, and since
+    // ASAuthorizationController's delegate/presentationContextProvider are weak, the completion
+    // callback (success or failure) is silently dropped and the Dart Future hangs forever.
+    private var inFlightPasskeyService: AnyObject?
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "credential_manager", binaryMessenger: registrar.messenger())
@@ -31,8 +37,12 @@ public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     }
     private func savePassKeyCredentials(call: FlutterMethodCall, result: @escaping FlutterResult) {
         if #available(iOS 16.0, *) {
-            let passkeyService: PasskeyService = PasskeyService()
-            passkeyService.registerPasskeyCredentials(call: call, result: result)
+            let passkeyService = PasskeyService()
+            inFlightPasskeyService = passkeyService
+            passkeyService.registerPasskeyCredentials(call: call) { [weak self] res in
+                self?.inFlightPasskeyService = nil
+                result(res)
+            }
         } else {
             result(FlutterError(
                 code: String(describing: CustomErrors.unsupportedPlatform),
@@ -43,10 +53,14 @@ public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     }
     private func getPasskeyCredentials(call: FlutterMethodCall, result: @escaping FlutterResult) {
         if #available(iOS 16.0, *) {
-            let passkeyService: PasskeyService = PasskeyService()
+            let passkeyService = PasskeyService()
+            inFlightPasskeyService = passkeyService
             passkeyService.getPasskeyCredentials(
                 call: call,
-                result: result,
+                result: { [weak self] res in
+                    self?.inFlightPasskeyService = nil
+                    result(res)
+                },
                 preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
             )
         } else {

--- a/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/CredentialManager.swift
+++ b/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/CredentialManager.swift
@@ -8,12 +8,14 @@ protocol Cancellable {
 
 public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     var preferImmediatelyAvailableCredentials: Bool = false
-    // Keeps the in-flight PasskeyService alive until its FlutterResult fires. Without this,
-    // the local `PasskeyService` in savePassKeyCredentials/getPasskeyCredentials below is the
-    // only strong reference to it; it deallocates as soon as that method returns, and since
+    // Keeps every in-flight PasskeyService alive until its own FlutterResult fires. Without
+    // this, the local `PasskeyService` in savePassKeyCredentials/getPasskeyCredentials below is
+    // the only strong reference to it; it deallocates as soon as that method returns, and since
     // ASAuthorizationController's delegate/presentationContextProvider are weak, the completion
-    // callback (success or failure) is silently dropped and the Dart Future hangs forever.
-    private var inFlightPasskeyService: AnyObject?
+    // callback (success or failure) is silently dropped and the Dart Future hangs forever. A
+    // plain array (not a single var) is required: a second passkey call overlapping the first
+    // must not release the first service out from under its still-in-flight authorization.
+    private var inFlightPasskeyServices: [AnyObject] = []
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "credential_manager", binaryMessenger: registrar.messenger())
@@ -38,9 +40,9 @@ public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     private func savePassKeyCredentials(call: FlutterMethodCall, result: @escaping FlutterResult) {
         if #available(iOS 16.0, *) {
             let passkeyService = PasskeyService()
-            inFlightPasskeyService = passkeyService
+            inFlightPasskeyServices.append(passkeyService)
             passkeyService.registerPasskeyCredentials(call: call) { [weak self] res in
-                self?.inFlightPasskeyService = nil
+                self?.inFlightPasskeyServices.removeAll { $0 === passkeyService }
                 result(res)
             }
         } else {
@@ -54,11 +56,11 @@ public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     private func getPasskeyCredentials(call: FlutterMethodCall, result: @escaping FlutterResult) {
         if #available(iOS 16.0, *) {
             let passkeyService = PasskeyService()
-            inFlightPasskeyService = passkeyService
+            inFlightPasskeyServices.append(passkeyService)
             passkeyService.getPasskeyCredentials(
                 call: call,
                 result: { [weak self] res in
-                    self?.inFlightPasskeyService = nil
+                    self?.inFlightPasskeyServices.removeAll { $0 === passkeyService }
                     result(res)
                 },
                 preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials

--- a/packages/credential_manager_ios/pubspec.yaml
+++ b/packages/credential_manager_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: credential_manager_ios
 description: iOS implementation of the credential_manager plugin using Keychain and Autofill.
-version: 3.1.0
+version: 3.2.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose$
 

--- a/packages/scripts/auto-release.sh
+++ b/packages/scripts/auto-release.sh
@@ -1,0 +1,257 @@
+#!/bin/bash
+# Automates the mechanical parts of a release: detects which packages have real
+# (non-doc) code changes since the last release, asks Claude Code in headless
+# mode ONLY to classify each change as "minor" or "major" per this repo's
+# version-bump convention (bug fix/small change -> minor; migration/new
+# feature/breaking change -> major — see CLAUDE.md), then bumps
+# pubspec.yaml/CHANGELOG.md, propagates the bump to dependents, runs the
+# make check gate, and opens a PR to develop.
+#
+# This intentionally stops at "PR opened against develop". It never merges a
+# PR, never promotes develop -> main, and never runs `flutter pub publish`
+# (dry-run or real) — those stay manual/interactive steps per this repo's
+# safety policy (CLAUDE.md: main requires human review; a real publish is
+# irreversible and needs explicit per-package confirmation). See the
+# `publish-release` skill for those remaining steps.
+#
+# Usage:
+#   packages/scripts/auto-release.sh [--dry-run] [--base <ref>] [--yes] [--model <model>]
+#
+#   --dry-run       Show the classification + version-bump plan, change nothing.
+#   --base <ref>    Ref to diff against to find changes (default: origin/main).
+#   --yes           Skip the confirmation prompt before branching/committing/pushing.
+#   --model <model> Model passed to `claude --model` for classification (default: haiku).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+DRY_RUN=false
+BASE_REF="origin/main"
+ASSUME_YES=false
+CLASSIFY_MODEL="haiku"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run) DRY_RUN=true; shift ;;
+    --base) BASE_REF="$2"; shift 2 ;;
+    --yes) ASSUME_YES=true; shift ;;
+    --model) CLASSIFY_MODEL="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,25p' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+info()    { echo -e "${BLUE}ℹ${NC} $1"; }
+ok()      { echo -e "${GREEN}✓${NC} $1"; }
+warn()    { echo -e "${YELLOW}⚠${NC} $1"; }
+fail()    { echo -e "${RED}✗${NC} $1" >&2; exit 1; }
+
+command -v claude >/dev/null 2>&1 || fail "claude CLI not found on PATH"
+command -v gh >/dev/null 2>&1 || fail "gh CLI not found on PATH"
+
+# Ordered so that a package always appears after everything it depends on.
+PACKAGE_ORDER=(credential_manager_platform_interface credential_manager_android credential_manager_ios credential_manager_web credential_manager)
+
+# Source paths (relative to packages/<name>/) whose changes count as "real"
+# code changes for a package, as opposed to docs/example/CI churn.
+code_paths_for() {
+  case "$1" in
+    credential_manager_platform_interface) echo "lib" ;;
+    credential_manager_android) echo "lib android/src" ;;
+    credential_manager_ios) echo "lib ios/credential_manager_ios/Sources" ;;
+    credential_manager_web) echo "lib web/passkey_authenticator.js" ;;
+    credential_manager) echo "lib" ;; # example/ deliberately excluded: not published
+  esac
+}
+
+# Packages that depend on a given package (direct edges of the fixed graph).
+dependents_of() {
+  case "$1" in
+    credential_manager_platform_interface) echo "credential_manager_android credential_manager_ios credential_manager_web credential_manager" ;;
+    credential_manager_android) echo "credential_manager" ;;
+    credential_manager_ios) echo "credential_manager" ;;
+    credential_manager_web) echo "credential_manager" ;;
+    credential_manager) echo "" ;;
+  esac
+}
+
+get_version() { grep "^version:" "packages/$1/pubspec.yaml" | sed 's/version: *//' | tr -d ' \r'; }
+
+bump_version() {
+  local version=$1 kind=$2
+  IFS='.' read -r major minor patch <<< "$version"
+  if [ "$kind" = "major" ]; then
+    echo "$((major + 1)).0.0"
+  else
+    echo "${major}.$((minor + 1)).0"
+  fi
+}
+
+info "Fetching $BASE_REF..."
+git fetch origin "${BASE_REF#origin/}" --quiet 2>/dev/null || true
+
+# bash 3.2 (macOS default) has no associative arrays, so per-package decision/
+# version state lives in a scratch dir instead of `declare -A`.
+STATE_DIR=$(mktemp -d)
+trap 'rm -rf "$STATE_DIR"' EXIT
+
+decision_of() { cat "$STATE_DIR/$1.decision" 2>/dev/null || true; }
+set_decision() { printf '%s' "$2" > "$STATE_DIR/$1.decision"; }
+version_of() { cat "$STATE_DIR/$1.version" 2>/dev/null || true; }
+set_version() { printf '%s' "$2" > "$STATE_DIR/$1.version"; }
+
+classify_package() {
+  local pkg=$1
+  local paths
+  paths=$(code_paths_for "$pkg")
+  local diff
+  diff=$(cd "packages/$pkg" && git diff "$BASE_REF"...HEAD -- $paths 2>/dev/null || true)
+
+  if [ -z "$diff" ]; then
+    return
+  fi
+
+  info "Classifying $pkg (real code changes detected)..."
+  # Built via a temp file (not an interpolated heredoc) so diff content
+  # containing backticks/$()/etc. can't be misparsed by the shell.
+  local prompt_file
+  prompt_file=$(mktemp)
+  {
+    printf 'Classify this code change per the flutter_credential_manager_compose repo'\''s own\n'
+    printf 'version-bump convention (not standard semver):\n'
+    printf -- '- Bug fix / small change -> minor\n'
+    printf -- '- Migration / new feature / breaking change -> major\n\n'
+    printf 'Package: %s\n\n' "$pkg"
+    printf 'Diff:\n'
+    printf '%s\n' "$diff"
+    printf '\nRespond with exactly one word, lowercase, no punctuation: major or minor.\n'
+  } > "$prompt_file"
+
+  local result
+  result=$(claude -p --model "$CLASSIFY_MODEL" --output-format text < "$prompt_file" 2>/dev/null \
+    | tr '[:upper:]' '[:lower:]' | grep -oE 'major|minor' | head -1)
+  rm -f "$prompt_file"
+
+  if [ "$result" != "major" ] && [ "$result" != "minor" ]; then
+    warn "Could not get a clean classification for $pkg (got: '$result') — defaulting to minor"
+    result="minor"
+  fi
+  set_decision "$pkg" "$result"
+  ok "$pkg -> $result bump"
+}
+
+for pkg in "${PACKAGE_ORDER[@]}"; do
+  classify_package "$pkg"
+done
+
+# Propagate: any package whose dependency got bumped needs at least a minor
+# bump too, even with no code changes of its own, so its constraint can be
+# updated. A package's own classification (if it has real changes) wins if
+# it's already "major".
+for pkg in "${PACKAGE_ORDER[@]}"; do
+  for dep in "${PACKAGE_ORDER[@]}"; do
+    if [[ " $(dependents_of "$dep") " == *" $pkg "* ]] && [ -n "$(decision_of "$dep")" ] && [ -z "$(decision_of "$pkg")" ]; then
+      set_decision "$pkg" "minor"
+    fi
+  done
+done
+
+any_change=false
+for pkg in "${PACKAGE_ORDER[@]}"; do
+  if [ -n "$(decision_of "$pkg")" ]; then
+    any_change=true
+    old_version=$(get_version "$pkg")
+    printf '%s' "$old_version" > "$STATE_DIR/$pkg.oldversion"
+    set_version "$pkg" "$(bump_version "$old_version" "$(decision_of "$pkg")")"
+  fi
+done
+old_version_of() { cat "$STATE_DIR/$1.oldversion" 2>/dev/null || true; }
+
+if [ "$any_change" = false ]; then
+  ok "No packages have code changes since $BASE_REF. Nothing to release."
+  exit 0
+fi
+
+echo ""
+info "Release plan:"
+for pkg in "${PACKAGE_ORDER[@]}"; do
+  if [ -n "$(decision_of "$pkg")" ]; then
+    printf "  %-40s %s -> %s (%s)\n" "$pkg" "$(old_version_of "$pkg")" "$(version_of "$pkg")" "$(decision_of "$pkg")"
+  fi
+done
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+  ok "Dry run only — no files changed."
+  exit 0
+fi
+
+if [ "$ASSUME_YES" != true ]; then
+  read -p "Apply this plan and open a PR against develop? (y/N): " -n 1 -r
+  echo
+  [[ $REPLY =~ ^[Yy]$ ]] || { info "Aborted."; exit 0; }
+fi
+
+git checkout develop
+git pull origin develop --quiet
+slug="auto-release-$(date +%Y%m%d-%H%M%S)"
+git checkout -b "$slug"
+
+for pkg in "${PACKAGE_ORDER[@]}"; do
+  [ -z "$(decision_of "$pkg")" ] && continue
+  new_version=$(version_of "$pkg")
+  pubspec="packages/$pkg/pubspec.yaml"
+  sed -i.bak "s/^version: .*/version: $new_version/" "$pubspec" && rm "$pubspec.bak"
+
+  # Update this package's constraint in every dependent's pubspec.yaml.
+  for dependent in $(dependents_of "$pkg"); do
+    [ -z "$(decision_of "$dependent")" ] && continue
+    dep_pubspec="packages/$dependent/pubspec.yaml"
+    sed -i.bak "s/^\(  $pkg: \)\^.*/\1^$new_version/" "$dep_pubspec" && rm "$dep_pubspec.bak"
+  done
+
+  changelog="packages/$pkg/CHANGELOG.md"
+  commits=$(cd "packages/$pkg" && git log "$BASE_REF"...HEAD --format="- %s" -- $(code_paths_for "$pkg") 2>/dev/null || true)
+  [ -z "$commits" ] && commits="- (add release notes here)"
+  entry="# $new_version
+$commits
+
+"
+  # Demote the previous newest ("# x.y.z") entry to "## x.y.z" and prepend the new one.
+  if head -1 "$changelog" | grep -qE '^# '; then
+    sed -i.bak '1s/^# /## /' "$changelog" && rm "$changelog.bak"
+  fi
+  tmp=$(mktemp)
+  printf '%s' "$entry" > "$tmp"
+  cat "$changelog" >> "$tmp"
+  mv "$tmp" "$changelog"
+
+  ok "Bumped $pkg to $new_version"
+done
+
+info "Running make bootstrap && make check..."
+make bootstrap
+make check
+
+git add -A
+commit_msg="chore: auto-release $(for pkg in "${PACKAGE_ORDER[@]}"; do [ -n "$(decision_of "$pkg")" ] && echo -n "$pkg@$(version_of "$pkg") "; done)"
+git commit -m "$commit_msg"
+git push -u origin "$slug"
+
+pr_body="Auto-generated release plan (classified by \`claude --model $CLASSIFY_MODEL\`, review before merging):
+
+$(for pkg in "${PACKAGE_ORDER[@]}"; do [ -n "$(decision_of "$pkg")" ] && echo "- \`$pkg\`: $(old_version_of "$pkg") -> $(version_of "$pkg") ($(decision_of "$pkg"))"; done)
+
+CHANGELOG entries were drafted from commit subjects touching each package's source paths since \`$BASE_REF\` — edit them before merging if they need more context.
+
+This PR does not merge itself, promote to main, or publish — do those manually per the \`publish-release\` skill once this looks right."
+
+gh pr create --base develop --title "$commit_msg" --body "$pr_body"
+
+ok "Done. Review the CHANGELOG entries in the PR before merging."

--- a/packages/scripts/auto-release.sh
+++ b/packages/scripts/auto-release.sh
@@ -93,8 +93,17 @@ bump_version() {
   fi
 }
 
+[ "$(git branch --show-current)" = "develop" ] || fail "Run this script from develop (checkout develop first)"
+[ -z "$(git status --porcelain)" ] || fail "Working tree is not clean — commit, stash, or discard changes first"
+info "Fast-forwarding develop..."
+git fetch origin develop --quiet || fail "Could not fetch origin/develop"
+git merge --ff-only origin/develop || fail "develop has local commits not on origin/develop — reconcile first"
+
 info "Fetching $BASE_REF..."
-git fetch origin "${BASE_REF#origin/}" --quiet 2>/dev/null || true
+if [[ "$BASE_REF" == origin/* ]]; then
+  git fetch origin "${BASE_REF#origin/}" --quiet || fail "Could not fetch $BASE_REF"
+fi
+git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null || fail "Base ref does not resolve: $BASE_REF"
 
 # bash 3.2 (macOS default) has no associative arrays, so per-package decision/
 # version state lives in a scratch dir instead of `declare -A`.
@@ -198,8 +207,6 @@ if [ "$ASSUME_YES" != true ]; then
   [[ $REPLY =~ ^[Yy]$ ]] || { info "Aborted."; exit 0; }
 fi
 
-git checkout develop
-git pull origin develop --quiet
 slug="auto-release-$(date +%Y%m%d-%H%M%S)"
 git checkout -b "$slug"
 


### PR DESCRIPTION
## Summary
Promotes `develop` to `main`, bringing in:
- #93 — fix #92: iOS passkey `savePasskeyCredentials`/`getCredentials` could hang forever due to a native retain-cycle bug (`credential_manager_ios` 3.1.0 → 3.2.0, `credential_manager` 4.1.0 → 4.2.0)
- #94 — fix CI Android build: Gradle 8.10.2 → 9.1.0, AGP 8.6.0 → 9.0.1, migrated off explicit `kotlin-android` plugin to Flutter's built-in Kotlin support (`credential_manager_android` 3.1.0 → 3.2.0, `credential_manager` 4.2.0 → 4.3.0)
- #91 — `auto-release.sh` script to automate mechanical parts of future releases
- Earlier already-merged `develop` commits not yet promoted (PR #79 CodeRabbit findings, platform_interface version fix, etc.)

## Test plan
- [x] All CI checks passed on both #93 and #94 individually before merge
- [ ] Full CI run on this promotion PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an iOS passkey issue that could cause operations to hang, including when multiple passkey requests run at the same time.

* **Improvements**
  * Updated credential manager packages and Android build tooling for improved compatibility.
  * Refreshed the package release to include a clean example project without functional or API changes.

* **Documentation**
  * Added release notes covering the package updates and passkey fix.
  * Documented an automated release workflow for maintainers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->