### PR TITLE
fix: iOS passkey hang (#92) — release credential_manager_ios 3.2.0

### DIFF
--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-# 4.1.0
+# 4.2.0
+- Bumped `credential_manager_ios` to `^3.2.0`, fixing #92: passkey registration/authentication
+  could silently hang forever on iOS (no exception, no error code) due to a native retain-cycle
+  bug introduced in `credential_manager_ios` 3.0.1 — see its own CHANGELOG for details
+- No breaking changes to this package's own public Dart API
+
+## 4.1.0
 - **Fixes a critical issue in 4.0.0**: that release depended on `credential_manager_platform_interface:
   ^2.0.8`, but the actual pub.dev `2.0.8` release predates the `nonce` parameter this package's
   Google Sign-In call relies on, breaking `flutter pub get`/analysis for anyone resolving from

--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 # 4.2.0
 - Bumped `credential_manager_ios` to `^3.2.0`, fixing #92: passkey registration/authentication
-  could silently hang forever on iOS (no exception, no error code) due to a native retain-cycle
-  bug introduced in `credential_manager_ios` 3.0.1 — see its own CHANGELOG for details
+  could silently hang forever on iOS (no exception, no error code) because `PasskeyService` was
+  deallocated before authorization completed in `credential_manager_ios` 3.0.1 — see its own
+  CHANGELOG for details
 - No breaking changes to this package's own public Dart API
 
 ## 4.1.0

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Credential Manager plugin. Provides one-tap login functionality and stores credentials
   in the user's Google account on Android and in the Keychain on iOS.
 
-version: 4.1.0
+version: 4.2.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 
@@ -18,7 +18,7 @@ dependencies:
     sdk: flutter
   credential_manager_platform_interface: ^3.0.0
   credential_manager_android: ^3.1.0
-  credential_manager_ios: ^3.1.0
+  credential_manager_ios: ^3.2.0
   credential_manager_web: ^2.2.0
 
 dev_dependencies:

--- a/packages/credential_manager_ios/CHANGELOG.md
+++ b/packages/credential_manager_ios/CHANGELOG.md
@@ -1,4 +1,17 @@
-# 3.1.0
+# 3.2.0
+- **Fixes #92: passkey registration/authentication silently hangs since 3.0.1.** `savePassKeyCredentials`
+  and `getPasskeyCredentials` created `PasskeyService` as a local variable with no strong reference
+  held anywhere; once the enclosing method returned, it deallocated immediately. Since
+  `ASAuthorizationController`'s delegate and presentation-context-provider are held weakly, this
+  silently dropped the completion callback (success or failure) and the Dart `Future` never
+  resolved — no exception, no error code, forever. `[weak self]` in `PasskeyService`'s own
+  completion closures (added in 3.0.1's SwiftLint cleanup) is what exposed this: previously an
+  unintentional retain cycle kept the object graph alive long enough to mask the bug.
+- `CredentialManagerPlugin` now holds a strong `inFlightPasskeyService` reference for the duration
+  of each passkey call, cleared once its `FlutterResult` fires.
+- No breaking changes to the public Dart API
+
+## 3.1.0
 - Bumped `credential_manager_platform_interface` to `^3.0.0` (required — the previously-declared
   `^2.0.8` resolves to a published version that predates the `nonce` parameter this package's
   `saveGoogleCredential` override already relies on)

--- a/packages/credential_manager_ios/CHANGELOG.md
+++ b/packages/credential_manager_ios/CHANGELOG.md
@@ -7,8 +7,10 @@
   resolved — no exception, no error code, forever. `[weak self]` in `PasskeyService`'s own
   completion closures (added in 3.0.1's SwiftLint cleanup) is what exposed this: previously an
   unintentional retain cycle kept the object graph alive long enough to mask the bug.
-- `CredentialManagerPlugin` now holds a strong `inFlightPasskeyService` reference for the duration
-  of each passkey call, cleared once its `FlutterResult` fires.
+- `CredentialManagerPlugin` now holds a strong reference to each in-flight `PasskeyService` for the
+  duration of its call, removed once its own `FlutterResult` fires. Uses a collection rather than a
+  single slot, so overlapping passkey calls (e.g. register and get in flight together) don't cause
+  one call's `PasskeyService` to release another's out from under its still-active authorization.
 - No breaking changes to the public Dart API
 
 ## 3.1.0

--- a/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/CredentialManager.swift
+++ b/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/CredentialManager.swift
@@ -8,6 +8,12 @@ protocol Cancellable {
 
 public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     var preferImmediatelyAvailableCredentials: Bool = false
+    // Keeps the in-flight PasskeyService alive until its FlutterResult fires. Without this,
+    // the local `PasskeyService` in savePassKeyCredentials/getPasskeyCredentials below is the
+    // only strong reference to it; it deallocates as soon as that method returns, and since
+    // ASAuthorizationController's delegate/presentationContextProvider are weak, the completion
+    // callback (success or failure) is silently dropped and the Dart Future hangs forever.
+    private var inFlightPasskeyService: AnyObject?
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "credential_manager", binaryMessenger: registrar.messenger())
@@ -31,8 +37,12 @@ public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     }
     private func savePassKeyCredentials(call: FlutterMethodCall, result: @escaping FlutterResult) {
         if #available(iOS 16.0, *) {
-            let passkeyService: PasskeyService = PasskeyService()
-            passkeyService.registerPasskeyCredentials(call: call, result: result)
+            let passkeyService = PasskeyService()
+            inFlightPasskeyService = passkeyService
+            passkeyService.registerPasskeyCredentials(call: call) { [weak self] res in
+                self?.inFlightPasskeyService = nil
+                result(res)
+            }
         } else {
             result(FlutterError(
                 code: String(describing: CustomErrors.unsupportedPlatform),
@@ -43,10 +53,14 @@ public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     }
     private func getPasskeyCredentials(call: FlutterMethodCall, result: @escaping FlutterResult) {
         if #available(iOS 16.0, *) {
-            let passkeyService: PasskeyService = PasskeyService()
+            let passkeyService = PasskeyService()
+            inFlightPasskeyService = passkeyService
             passkeyService.getPasskeyCredentials(
                 call: call,
-                result: result,
+                result: { [weak self] res in
+                    self?.inFlightPasskeyService = nil
+                    result(res)
+                },
                 preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials
             )
         } else {

--- a/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/CredentialManager.swift
+++ b/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/CredentialManager.swift
@@ -8,12 +8,14 @@ protocol Cancellable {
 
 public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     var preferImmediatelyAvailableCredentials: Bool = false
-    // Keeps the in-flight PasskeyService alive until its FlutterResult fires. Without this,
-    // the local `PasskeyService` in savePassKeyCredentials/getPasskeyCredentials below is the
-    // only strong reference to it; it deallocates as soon as that method returns, and since
+    // Keeps every in-flight PasskeyService alive until its own FlutterResult fires. Without
+    // this, the local `PasskeyService` in savePassKeyCredentials/getPasskeyCredentials below is
+    // the only strong reference to it; it deallocates as soon as that method returns, and since
     // ASAuthorizationController's delegate/presentationContextProvider are weak, the completion
-    // callback (success or failure) is silently dropped and the Dart Future hangs forever.
-    private var inFlightPasskeyService: AnyObject?
+    // callback (success or failure) is silently dropped and the Dart Future hangs forever. A
+    // plain array (not a single var) is required: a second passkey call overlapping the first
+    // must not release the first service out from under its still-in-flight authorization.
+    private var inFlightPasskeyServices: [AnyObject] = []
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "credential_manager", binaryMessenger: registrar.messenger())
@@ -38,9 +40,9 @@ public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     private func savePassKeyCredentials(call: FlutterMethodCall, result: @escaping FlutterResult) {
         if #available(iOS 16.0, *) {
             let passkeyService = PasskeyService()
-            inFlightPasskeyService = passkeyService
+            inFlightPasskeyServices.append(passkeyService)
             passkeyService.registerPasskeyCredentials(call: call) { [weak self] res in
-                self?.inFlightPasskeyService = nil
+                self?.inFlightPasskeyServices.removeAll { $0 === passkeyService }
                 result(res)
             }
         } else {
@@ -54,11 +56,11 @@ public class CredentialManagerPlugin: NSObject, FlutterPlugin {
     private func getPasskeyCredentials(call: FlutterMethodCall, result: @escaping FlutterResult) {
         if #available(iOS 16.0, *) {
             let passkeyService = PasskeyService()
-            inFlightPasskeyService = passkeyService
+            inFlightPasskeyServices.append(passkeyService)
             passkeyService.getPasskeyCredentials(
                 call: call,
                 result: { [weak self] res in
-                    self?.inFlightPasskeyService = nil
+                    self?.inFlightPasskeyServices.removeAll { $0 === passkeyService }
                     result(res)
                 },
                 preferImmediatelyAvailableCredentials: preferImmediatelyAvailableCredentials

--- a/packages/credential_manager_ios/pubspec.yaml
+++ b/packages/credential_manager_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: credential_manager_ios
 description: iOS implementation of the credential_manager plugin using Keychain and Autofill.
-version: 3.1.0
+version: 3.2.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose$
 


### PR DESCRIPTION
## Summary
iOS-only release, split out from #95 (which bundles this together with unrelated Android/AGP CI work still being finalized — see that PR's discussion). Cherry-picked from `develop`.

- Fixes #92: `savePasskeyCredentials`/`getCredentials(passKeyOption:)` could hang forever on iOS (no exception, no error code) since `credential_manager_ios` 3.0.1, because the plugin held no strong reference to the in-flight `PasskeyService` — it deallocated as soon as the enclosing method returned, silently dropping `ASAuthorizationController`'s (weak) delegate callback.
- `CredentialManagerPlugin` now retains each in-flight `PasskeyService` in a collection (not a single var) for the duration of its call, removed once its own `FlutterResult` fires — a single slot would let a second, overlapping passkey call release the first service out from under its still-active authorization, reintroducing the same hang.
- Bumps `credential_manager_ios` 3.1.0 → 3.2.0, `credential_manager` 4.1.0 → 4.2.0 (bug fix → minor bump per this repo's convention). **Does not** touch `credential_manager_android` — that stays at the already-published 3.1.0.

## Test plan
- [x] `make check` (format, analyze, SwiftLint, Detekt) passes cleanly
- [x] `xcodebuild` succeeds with the overlapping-calls fix
- [x] Reproduced the hang pre-fix on iOS Simulator (stuck loading spinner, no error surfaced); confirmed post-fix the call now returns/throws promptly instead of hanging
- [x] Diff against `main` confirmed iOS-only — no Android/AGP/CI-script changes included