### PR TITLE
chore: republish credential_manager 4.3.0 with clean example/

### DIFF
--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-# 4.2.0
+# 4.3.0
+- Republishes 4.2.0's contents with a clean `example/` directory. 4.2.0's published archive
+  accidentally included 4 locally-modified-but-uncommitted `example/ios/` files (Xcode-project
+  migration churn from local tooling, not a deliberate change) instead of what's committed to
+  `main` — cosmetic only (demo app scaffolding, not `lib/` or native plugin source), but
+  corrected here for a clean package listing. No functional or API changes.
+
+## 4.2.0
 - Bumped `credential_manager_ios` to `^3.2.0`, fixing #92: passkey registration/authentication
   could silently hang forever on iOS (no exception, no error code) because `PasskeyService` was
   deallocated before authorization completed in `credential_manager_ios` 3.0.1 — see its own

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Credential Manager plugin. Provides one-tap login functionality and stores credentials
   in the user's Google account on Android and in the Keychain on iOS.
 
-version: 4.2.0
+version: 4.3.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 


### PR DESCRIPTION
## Summary
`credential_manager` 4.2.0's published pub.dev archive accidentally included 4 uncommitted `example/ios/` files (local Xcode-project migration churn from tooling during a post-publish `flutter pub get`, not a deliberate change) instead of what's committed to `main`. Cosmetic only — confined to `example/ios/` demo-app scaffolding, never `lib/` or native plugin source, so no functional impact on consumers. pub.dev publishes are immutable, so 4.2.0 can't be corrected directly; this republishes the same content cleanly as 4.3.0.

No code changes — version bump + CHANGELOG entry only.

## Test plan
- [x] `git status` confirmed clean (matches `main`) before this commit
- [x] `make check` passes cleanly
- [x] Will dry-run `flutter pub publish` before the real publish, confirming 0 warnings and a clean `example/` tree in the file listing