### PR TITLE
Add Android credential preparation and honor immediate preference

### DIFF
--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Unreleased
+- Added `prepareCredentials`, which prefetches a matching Android credential request on Android 14 and newer and
+  returns `false` on unsupported platforms.
+
 # 4.3.0
 - Republishes 4.2.0's contents with a clean `example/` directory. 4.2.0's published archive
   accidentally included 4 locally-modified-but-uncommitted `example/ios/` files (Xcode-project

--- a/packages/credential_manager/lib/src/credential_manager_core.dart
+++ b/packages/credential_manager/lib/src/credential_manager_core.dart
@@ -45,10 +45,7 @@ class CredentialManager {
   /// [googleClientId] - The Google client ID to be used for Google credentials.
   ///
   /// Returns a [Future] that completes when initialization is successful.
-  Future<void> init({
-    required bool preferImmediatelyAvailableCredentials,
-    String? googleClientId,
-  }) async {
+  Future<void> init({required bool preferImmediatelyAvailableCredentials, String? googleClientId}) async {
     return CredentialManagerPlatform.instance.init(preferImmediatelyAvailableCredentials, googleClientId);
   }
 
@@ -79,6 +76,18 @@ class CredentialManager {
   /// Returns an empty [Credentials] object if no credentials are found.
   Future<Credentials> getCredentials({CredentialLoginOptions? passKeyOption, FetchOptionsAndroid? fetchOptions}) async {
     return CredentialManagerPlatform.instance.getCredentials(passKeyOption: passKeyOption, fetchOptions: fetchOptions);
+  }
+
+  /// Prepares a later credential request on platforms that support prefetching.
+  ///
+  /// The next [getCredentials] call with matching options consumes the
+  /// prepared request. Unsupported platforms return `false` and continue to
+  /// use the normal credential flow.
+  Future<bool> prepareCredentials({CredentialLoginOptions? passKeyOption, FetchOptionsAndroid? fetchOptions}) async {
+    return CredentialManagerPlatform.instance.prepareCredentials(
+      passKeyOption: passKeyOption,
+      fetchOptions: fetchOptions,
+    );
   }
 
   /// Saves Google credentials.

--- a/packages/credential_manager_android/CHANGELOG.md
+++ b/packages/credential_manager_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- `getCredentials` now applies the `preferImmediatelyAvailableCredentials` value supplied during initialization.
+- Added Android 14+ credential preparation. A matching `getCredentials` call consumes the prepared handle and falls
+  back to the normal request if the prefetched data can no longer be used.
+
 # 3.1.0
 - Bumped `credential_manager_platform_interface` to `^3.0.0` (required — the previously-declared
   `^2.0.8` resolves to a published version that predates the `nonce` parameter this package's
@@ -29,4 +34,3 @@
 - Initial release of Android implementation package
 - Android-specific implementation using Jetpack Credential Manager API
 - Supports password credentials, passkeys, and Google Sign-In
-

--- a/packages/credential_manager_android/README.md
+++ b/packages/credential_manager_android/README.md
@@ -13,6 +13,7 @@ This package is automatically included when you use `credential_manager` on Andr
 - Password credentials management
 - Google Sign-In credentials
 - Passkey support (WebAuthn)
+- Android 14+ credential preparation for a lower-latency account selector
 - Secure credential storage using Android Credential Manager
 
 ## Requirements
@@ -23,4 +24,3 @@ This package is automatically included when you use `credential_manager` on Andr
 ## License
 
 See the [LICENSE](../LICENSE) file for details.
-

--- a/packages/credential_manager_android/android/src/main/kotlin/com/smkwinner/cred_manager/credential_manager/CredentialManagerPlugin.kt
+++ b/packages/credential_manager_android/android/src/main/kotlin/com/smkwinner/cred_manager/credential_manager/CredentialManagerPlugin.kt
@@ -51,6 +51,7 @@ class CredentialManagerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
                     // Handling other credential-related methods
                     when (call.method) {
                         "save_password_credentials" -> handleSavePasswordCredentials(call, result)
+                        "prepare_credentials" -> handlePrepareCredentials(call, result, utils)
                         "get_password_credentials" -> handleGetPasswordCredentials(call, result)
                         "save_google_credential" -> handleSaveGoogleCredential(call, result)
                         "save_public_key_credential" -> handleSavePublicKeyCredential(call, result)
@@ -101,18 +102,8 @@ class CredentialManagerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
     }
 
     private suspend fun handleGetPasswordCredentials(call: MethodCall, result: Result) {
-        val requestJson: String? = call.argument("passKeyOption")
-        val fetchOptionsJson: String? = call.argument("fetchOptions")
-        val fetchOptions: FetchOptions? = fetchOptionsJson?.let {
-            val jsonObject = JSONObject(it)
-            FetchOptions(
-                passKeyOption = jsonObject.optBoolean("passKey", true),
-                googleCredential = jsonObject.optBoolean("googleCredential", true),
-                passwordCredential = jsonObject.optBoolean("passwordCredential", true)
-            )
-        }
-        // throw error if fetchOptions is null
-        if (fetchOptions == null) {
+        val request = call.credentialRequestArguments()
+        if (request == null) {
             result.error("604", "FetchOptions is null", "FetchOptions is required")
             return
         }
@@ -120,8 +111,8 @@ class CredentialManagerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
         val (exception: CredentialManagerExceptions?, credentials: CredentialManagerResponse?) =
             utils.getPasswordCredentials(
                 context = currentContext,
-                requestJson = requestJson,
-                fetchOptions = fetchOptions
+                requestJson = request.requestJson,
+                fetchOptions = request.fetchOptions
             )
 
         if (exception != null) {
@@ -235,5 +226,45 @@ class CredentialManagerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
 
     override fun onDetachedFromActivity() {
         activity = null
+    }
+}
+
+private data class CredentialRequestArguments(
+    val requestJson: String?,
+    val fetchOptions: FetchOptions
+)
+
+private fun MethodCall.credentialRequestArguments(): CredentialRequestArguments? {
+    val fetchOptionsJson: String = argument("fetchOptions") ?: return null
+    val jsonObject = JSONObject(fetchOptionsJson)
+    return CredentialRequestArguments(
+        requestJson = argument("passKeyOption"),
+        fetchOptions = FetchOptions(
+            passKeyOption = jsonObject.optBoolean("passKey", true),
+            googleCredential = jsonObject.optBoolean("googleCredential", true),
+            passwordCredential = jsonObject.optBoolean("passwordCredential", true)
+        )
+    )
+}
+
+private suspend fun handlePrepareCredentials(
+    call: MethodCall,
+    result: Result,
+    utils: CredentialManagerUtils
+) {
+    val request = call.credentialRequestArguments()
+    if (request == null) {
+        result.error("604", "FetchOptions is null", "FetchOptions is required")
+        return
+    }
+
+    val (exception: CredentialManagerExceptions?, prepared: Boolean) = utils.prepareCredentials(
+        requestJson = request.requestJson,
+        fetchOptions = request.fetchOptions
+    )
+    if (exception != null) {
+        result.error(exception.code.toString(), exception.message, exception.details)
+    } else {
+        result.success(prepared)
     }
 }

--- a/packages/credential_manager_android/android/src/main/kotlin/com/smkwinner/cred_manager/credential_manager/CredentialManagerUtils.kt
+++ b/packages/credential_manager_android/android/src/main/kotlin/com/smkwinner/cred_manager/credential_manager/CredentialManagerUtils.kt
@@ -2,8 +2,10 @@ package com.smkwinner.cred_manager.credential_manager
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.provider.Settings
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.credentials.ClearCredentialStateRequest
 import androidx.credentials.CreatePasswordRequest
 import androidx.credentials.CreatePublicKeyCredentialRequest
@@ -14,6 +16,7 @@ import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetPasswordOption
 import androidx.credentials.GetPublicKeyCredentialOption
 import androidx.credentials.PasswordCredential
+import androidx.credentials.PrepareGetCredentialResponse
 import androidx.credentials.PublicKeyCredential
 import androidx.credentials.exceptions.CreateCredentialCancellationException
 import androidx.credentials.exceptions.CreateCredentialException
@@ -27,6 +30,13 @@ import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
 import java.security.SecureRandom
+
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+private data class PreparedCredentialRequest(
+    val requestJson: String?,
+    val fetchOptions: FetchOptions,
+    val handle: PrepareGetCredentialResponse.PendingGetCredentialHandle
+)
 
 class CredentialManagerUtils {
     /**
@@ -43,6 +53,7 @@ class CredentialManagerUtils {
     private var preferImmediatelyAvailableCredentials: Boolean = true
     private lateinit var serverClientID: String
     private var isGmsAvailable: Boolean = false
+    private var preparedCredentialRequest: PreparedCredentialRequest? = null
 
     /**
      * Initialize the CredentialManagerUtils.
@@ -70,6 +81,7 @@ class CredentialManagerUtils {
 
             credentialManager = CredentialManager.create(context = context)
             this.preferImmediatelyAvailableCredentials = preferImmediatelyAvailableCredentials
+            preparedCredentialRequest = null
             if (gClientId != null) {
                 serverClientID = gClientId
             }
@@ -156,81 +168,39 @@ class CredentialManagerUtils {
         fetchOptions: FetchOptions
     ): Pair<CredentialManagerExceptions?, CredentialManagerResponse?> {
         return try {
-            // Check if all fetch options are disabled
-            if (!isAnyOptionEnabled(fetchOptions)) {
-                return Pair(
-                    CredentialManagerExceptions(
-                        code = 206,
-                        message = "Credential fetch options are not enabled",
-                        details = "Enable at least one credential fetch option (passkey, Google, or password)."
-                    ),
-                    null
-                )
-            }
-            val googleClientId = if (this::serverClientID.isInitialized) serverClientID else ""
-            // Validate serverClientID if Google sign-in is enabled
-            if (fetchOptions.googleCredential && googleClientId.isEmpty()) {
-                return Pair(
-                    CredentialManagerExceptions(
-                        code = 503,
-                        message = "Google client not initialized",
-                        details = "Ensure Google credentials are provided."
-                    ),
-                    null
-                )
-            }
+            validateCredentialRequest(requestJson, fetchOptions)?.let { return Pair(it, null) }
 
-            // Check if Google Play Services is available for Google credentials
-            if (fetchOptions.googleCredential && !isGmsAvailable) {
-                return Pair(
-                    CredentialManagerExceptions(
-                        code = 209,
-                        message = "Google Play Services not available",
-                        details = "Google Sign-In requires Google Play Services"
-                    ),
-                    null
-                )
+            val getCredRequest = buildGetCredentialRequest(requestJson, fetchOptions)
+            val preparedRequest = preparedCredentialRequest?.takeIf {
+                it.requestJson == requestJson && it.fetchOptions == fetchOptions
             }
-
-            // Validate requestJson for Passkey or Google Sign-In
-            if (fetchOptions.passKeyOption && requestJson == null) {
-                return Pair(
-                    CredentialManagerExceptions(
-                        code = 208,
-                        message = "RequestJson is required",
-                        details = "Provide requestJson for passkey."
-                    ),
-                    null
-                )
-            }
-
-            // Build the credential request based on enabled options
-            val getCredRequest = GetCredentialRequest.Builder().apply {
-                if (fetchOptions.passwordCredential) {
-                    addCredentialOption(GetPasswordOption())
-                }
-                if (fetchOptions.passKeyOption && requestJson != null) {
-                    addCredentialOption(GetPublicKeyCredentialOption(requestJson))
-                }
-                if (fetchOptions.googleCredential) {
-                    addCredentialOption(
-                        GetGoogleIdOption.Builder()
-                            .setFilterByAuthorizedAccounts(false)
-                            // No nonce here: this unified fetch path has no way to surface it to
-                            // the caller/backend for verification, so a generated-and-discarded
-                            // nonce would be misleading rather than real replay protection. Use
-                            // saveGoogleCredential(nonce: ...) when nonce verification is needed.
-                            .setServerClientId(serverClientID)
-                            .build()
-                    )
-                }
-            }.build()
+            preparedCredentialRequest = null
 
             // Fetch credentials using the credentialManager
-            val credentialResponse = credentialManager.getCredential(
-                request = getCredRequest,
-                context = context
-            )
+            val credentialResponse = if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+                preparedRequest != null
+            ) {
+                try {
+                    credentialManager.getCredential(
+                        context = context,
+                        pendingGetCredentialHandle = preparedRequest.handle
+                    )
+                } catch (e: GetCredentialCancellationException) {
+                    throw e
+                } catch (e: GetCredentialException) {
+                    Log.d("CredentialManager", "Prepared request failed; retrying without prefetched data", e)
+                    credentialManager.getCredential(
+                        request = getCredRequest,
+                        context = context
+                    )
+                }
+            } else {
+                credentialManager.getCredential(
+                    request = getCredRequest,
+                    context = context
+                )
+            }
 
             val response = when (val credential = credentialResponse.credential) {
                 is PasswordCredential -> {
@@ -350,6 +320,114 @@ class CredentialManagerUtils {
     }
 
     /**
+     * Prepares a credential request for a lower-latency selector on Android 14 and newer.
+     * The next [getPasswordCredentials] call with matching options consumes the prepared request.
+     */
+    suspend fun prepareCredentials(
+        requestJson: String?,
+        fetchOptions: FetchOptions
+    ): Pair<CredentialManagerExceptions?, Boolean> {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            preparedCredentialRequest = null
+            return Pair(null, false)
+        }
+        validateCredentialRequest(requestJson, fetchOptions)?.let { return Pair(it, false) }
+
+        return prepareCredentialsForAndroid14(requestJson, fetchOptions)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private suspend fun prepareCredentialsForAndroid14(
+        requestJson: String?,
+        fetchOptions: FetchOptions
+    ): Pair<CredentialManagerExceptions?, Boolean> {
+        preparedCredentialRequest = null
+        return try {
+            val response = credentialManager.prepareGetCredential(buildGetCredentialRequest(requestJson, fetchOptions))
+            val handle = response.pendingGetCredentialHandle ?: return Pair(null, false)
+            preparedCredentialRequest = PreparedCredentialRequest(
+                requestJson = requestJson,
+                fetchOptions = fetchOptions,
+                handle = handle
+            )
+            Pair(null, true)
+        } catch (e: NoCredentialException) {
+            preparedCredentialRequest = null
+            Log.d("CredentialManager", "No credentials available during preparation", e)
+            Pair(null, false)
+        } catch (e: GetCredentialException) {
+            preparedCredentialRequest = null
+            Pair(
+                CredentialManagerExceptions(
+                    code = 204,
+                    message = "Credential preparation failed ${e.localizedMessage}",
+                    details = e.stackTraceToString()
+                ),
+                false
+            )
+        }
+    }
+
+    private fun validateCredentialRequest(
+        requestJson: String?,
+        fetchOptions: FetchOptions
+    ): CredentialManagerExceptions? {
+        if (!isAnyOptionEnabled(fetchOptions)) {
+            return CredentialManagerExceptions(
+                code = 206,
+                message = "Credential fetch options are not enabled",
+                details = "Enable at least one credential fetch option (passkey, Google, or password)."
+            )
+        }
+
+        val googleClientId = if (this::serverClientID.isInitialized) serverClientID else ""
+        if (fetchOptions.googleCredential && googleClientId.isEmpty()) {
+            return CredentialManagerExceptions(
+                code = 503,
+                message = "Google client not initialized",
+                details = "Ensure Google credentials are provided."
+            )
+        }
+        if (fetchOptions.googleCredential && !isGmsAvailable) {
+            return CredentialManagerExceptions(
+                code = 209,
+                message = "Google Play Services not available",
+                details = "Google Sign-In requires Google Play Services"
+            )
+        }
+        if (fetchOptions.passKeyOption && requestJson == null) {
+            return CredentialManagerExceptions(
+                code = 208,
+                message = "RequestJson is required",
+                details = "Provide requestJson for passkey."
+            )
+        }
+        return null
+    }
+
+    private fun buildGetCredentialRequest(
+        requestJson: String?,
+        fetchOptions: FetchOptions
+    ): GetCredentialRequest = GetCredentialRequest.Builder().apply {
+        setPreferImmediatelyAvailableCredentials(preferImmediatelyAvailableCredentials)
+        if (fetchOptions.passwordCredential) {
+            addCredentialOption(GetPasswordOption())
+        }
+        if (fetchOptions.passKeyOption && requestJson != null) {
+            addCredentialOption(GetPublicKeyCredentialOption(requestJson))
+        }
+        if (fetchOptions.googleCredential) {
+            addCredentialOption(
+                GetGoogleIdOption.Builder()
+                    .setFilterByAuthorizedAccounts(false)
+                    // This unified path cannot surface a nonce for backend verification.
+                    .setServerClientId(serverClientID)
+                    .build()
+            )
+        }
+    }.build()
+
+    /**
      * Save Google credentials.
      *
      * @param context The Android context.
@@ -398,6 +476,7 @@ class CredentialManagerUtils {
         }
 
         val request: GetCredentialRequest = GetCredentialRequest.Builder()
+            .setPreferImmediatelyAvailableCredentials(preferImmediatelyAvailableCredentials)
             .addCredentialOption(googleCredentialOption)
             .build()
 

--- a/packages/credential_manager_android/lib/src/credential_manager_android.dart
+++ b/packages/credential_manager_android/lib/src/credential_manager_android.dart
@@ -31,75 +31,42 @@ class CredentialManagerAndroid extends CredentialManagerPlatform {
   }
 
   @override
-  Future<void> init(
-    bool preferImmediatelyAvailableCredentials,
-    String? googleClientId,
-  ) async {
-    final res = await methodChannel.invokeMethod<Map<Object?, Object?>>(
-      "init",
-      {
-        'prefer_immediately_available_credentials': preferImmediatelyAvailableCredentials,
-        'google_client_id': googleClientId,
-      },
-    );
+  Future<void> init(bool preferImmediatelyAvailableCredentials, String? googleClientId) async {
+    final res = await methodChannel.invokeMethod<Map<Object?, Object?>>("init", {
+      'prefer_immediately_available_credentials': preferImmediatelyAvailableCredentials,
+      'google_client_id': googleClientId,
+    });
 
     if (res != null && res['message'] == "Initialization successful") {
       _isGmsAvailable = res['isGmsAvailable'] as bool? ?? true;
       return;
     }
 
-    throw CredentialException(
-      code: 101,
-      message: "Initialization failure",
-      details: null,
-    );
+    throw CredentialException(code: 101, message: "Initialization failure", details: null);
   }
 
   @override
   Future<void> savePasswordCredentials(PasswordCredential credential) async {
     try {
-      final res = await methodChannel.invokeMethod<String>(
-        'save_password_credentials',
-        credential.toJson(),
-      );
+      final res = await methodChannel.invokeMethod<String>('save_password_credentials', credential.toJson());
 
       if (res != null && res == "Credentials saved") {
         return;
       }
 
-      throw CredentialException(
-        code: 302,
-        message: "Create Credentials failed",
-        details: null,
-      );
+      throw CredentialException(code: 302, message: "Create Credentials failed", details: null);
     } on PlatformException catch (e) {
-      throw PlatformExceptionHandler.handlePlatformException(
-        e,
-        CredentialType.passwordCredentials,
-      );
+      throw PlatformExceptionHandler.handlePlatformException(e, CredentialType.passwordCredentials);
     }
   }
 
   @override
-  Future<Credentials> getCredentials({
-    CredentialLoginOptions? passKeyOption,
-    FetchOptionsAndroid? fetchOptions,
-  }) async {
+  Future<Credentials> getCredentials({CredentialLoginOptions? passKeyOption, FetchOptionsAndroid? fetchOptions}) async {
     CredentialType credentialType = CredentialType.passwordCredentials;
     try {
-      String methodName = "get_password_credentials";
-      var methodParams = {};
-
-      if (passKeyOption != null) {
-        methodParams = {"passKeyOption": jsonEncode(passKeyOption.toJson())};
-      }
-
-      fetchOptions ??= FetchOptionsAndroid.all();
-      methodParams.addAll({"fetchOptions": jsonEncode(fetchOptions.toJson())});
-
       final res = await methodChannel.invokeMethod<Map<Object?, Object?>>(
-        methodName,
-        methodParams,
+        'get_password_credentials',
+        _credentialRequestParameters(passKeyOption: passKeyOption, fetchOptions: fetchOptions),
       );
 
       if (res != null) {
@@ -117,20 +84,43 @@ class CredentialManagerAndroid extends CredentialManagerPlatform {
       if (e.code == '202') {
         return Credentials();
       }
-      throw PlatformExceptionHandler.handlePlatformException(
-        e,
-        credentialType,
-      );
+      throw PlatformExceptionHandler.handlePlatformException(e, credentialType);
     }
+  }
+
+  @override
+  Future<bool> prepareCredentials({CredentialLoginOptions? passKeyOption, FetchOptionsAndroid? fetchOptions}) async {
+    try {
+      final prepared = await methodChannel.invokeMethod<bool>(
+        'prepare_credentials',
+        _credentialRequestParameters(passKeyOption: passKeyOption, fetchOptions: fetchOptions),
+      );
+      return prepared ?? false;
+    } on PlatformException catch (e) {
+      throw PlatformExceptionHandler.handlePlatformException(e, CredentialType.passwordCredentials);
+    }
+  }
+
+  Map<String, String> _credentialRequestParameters({
+    CredentialLoginOptions? passKeyOption,
+    FetchOptionsAndroid? fetchOptions,
+  }) {
+    final parameters = <String, String>{};
+    if (passKeyOption != null) {
+      parameters['passKeyOption'] = jsonEncode(passKeyOption.toJson());
+    }
+
+    parameters['fetchOptions'] = jsonEncode((fetchOptions ?? FetchOptionsAndroid.all()).toJson());
+    return parameters;
   }
 
   @override
   Future<GoogleIdTokenCredential?> saveGoogleCredential(bool useButtonFlow, {String? nonce}) async {
     try {
-      final res = await methodChannel.invokeMethod<Map<Object?, Object?>>(
-        'save_google_credential',
-        {"useButtonFlow": useButtonFlow, "nonce": nonce},
-      );
+      final res = await methodChannel.invokeMethod<Map<Object?, Object?>>('save_google_credential', {
+        "useButtonFlow": useButtonFlow,
+        "nonce": nonce,
+      });
 
       if (res == null) {
         throw CredentialException(
@@ -141,22 +131,16 @@ class CredentialManagerAndroid extends CredentialManagerPlatform {
       }
       return GoogleIdTokenCredential.fromJson(jsonDecode(jsonEncode(res)));
     } on PlatformException catch (e) {
-      throw PlatformExceptionHandler.handlePlatformException(
-        e,
-        CredentialType.googleIdTokenCredentials,
-      );
+      throw PlatformExceptionHandler.handlePlatformException(e, CredentialType.googleIdTokenCredentials);
     }
   }
 
   @override
-  Future<PublicKeyCredential> savePasskeyCredentials({
-    required CredentialCreationOptions request,
-  }) async {
+  Future<PublicKeyCredential> savePasskeyCredentials({required CredentialCreationOptions request}) async {
     try {
-      final res = await methodChannel.invokeMethod<String>(
-        'save_public_key_credential',
-        {"requestJson": jsonEncode(request.toJson())},
-      );
+      final res = await methodChannel.invokeMethod<String>('save_public_key_credential', {
+        "requestJson": jsonEncode(request.toJson()),
+      });
 
       if (res != null) {
         var data = res.toString();
@@ -164,16 +148,9 @@ class CredentialManagerAndroid extends CredentialManagerPlatform {
         return credential;
       }
 
-      throw CredentialException(
-        code: 302,
-        message: "Create Credentials failed",
-        details: null,
-      );
+      throw CredentialException(code: 302, message: "Create Credentials failed", details: null);
     } on PlatformException catch (e) {
-      throw PlatformExceptionHandler.handlePlatformException(
-        e,
-        CredentialType.publicKeyCredentials,
-      );
+      throw PlatformExceptionHandler.handlePlatformException(e, CredentialType.publicKeyCredentials);
     }
   }
 
@@ -183,11 +160,7 @@ class CredentialManagerAndroid extends CredentialManagerPlatform {
     if (res != null && res == "Logout successful") {
       return;
     }
-    throw CredentialException(
-      code: 504,
-      message: "Logout failed",
-      details: null,
-    );
+    throw CredentialException(code: 504, message: "Logout failed", details: null);
   }
 
   @override

--- a/packages/credential_manager_android/test/credential_manager_android_test.dart
+++ b/packages/credential_manager_android/test/credential_manager_android_test.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:credential_manager_android/credential_manager_android.dart';
+import 'package:credential_manager_platform_interface/credential_manager_platform_interface.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('credential_manager_test');
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('prepareCredentials forwards the same options used by getCredentials', () async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      if (call.method == 'prepare_credentials') return true;
+      if (call.method == 'get_password_credentials') {
+        return <String, Object?>{
+          'type': 'PasswordCredentials',
+          'data': <String, Object?>{'username': 'alex@example.com', 'password': 'secret-password'},
+        };
+      }
+      return null;
+    });
+
+    final manager = CredentialManagerAndroid(channel: channel);
+    final options = FetchOptionsAndroid(passwordCredential: true);
+
+    expect(await manager.prepareCredentials(fetchOptions: options), isTrue);
+    final credentials = await manager.getCredentials(fetchOptions: options);
+
+    expect(credentials.passwordCredential?.username, 'alex@example.com');
+    expect(calls.map((call) => call.method), ['prepare_credentials', 'get_password_credentials']);
+    expect(calls[0].arguments, calls[1].arguments);
+    expect(jsonDecode((calls[0].arguments as Map<Object?, Object?>)['fetchOptions']! as String), {
+      'passKey': false,
+      'googleCredential': false,
+      'passwordCredential': true,
+    });
+  });
+
+  test('prepareCredentials reports when native preparation is unsupported', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      (_) async => false,
+    );
+
+    final manager = CredentialManagerAndroid(channel: channel);
+
+    expect(await manager.prepareCredentials(fetchOptions: FetchOptionsAndroid(passwordCredential: true)), isFalse);
+  });
+}

--- a/packages/credential_manager_platform_interface/CHANGELOG.md
+++ b/packages/credential_manager_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Added a backward-compatible `prepareCredentials` platform hook that defaults to `false` on unsupported platforms.
+
 # 3.0.0
 - **Breaking:** `CredentialManagerPlatform.saveGoogleCredential` gains an optional named `{String?
   nonce}` parameter. This was actually added in a prior commit without a version bump — the
@@ -34,4 +37,3 @@
 - Initial release of platform interface package
 - Provides abstract `CredentialManagerPlatform` class
 - Supports modular plugin architecture
-

--- a/packages/credential_manager_platform_interface/lib/src/credential_manager_platform_interface.dart
+++ b/packages/credential_manager_platform_interface/lib/src/credential_manager_platform_interface.dart
@@ -52,10 +52,7 @@ abstract class CredentialManagerPlatform extends PlatformInterface {
   /// [googleClientId] - The Google client ID to be used for Google credentials.
   ///
   /// Returns a [Future] that completes when initialization is successful.
-  Future<void> init(
-    bool preferImmediatelyAvailableCredentials,
-    String? googleClientId,
-  );
+  Future<void> init(bool preferImmediatelyAvailableCredentials, String? googleClientId);
 
   /// Saves password credentials.
   ///
@@ -71,10 +68,19 @@ abstract class CredentialManagerPlatform extends PlatformInterface {
   ///
   /// Returns a [Future] that completes with [Credentials] representing the retrieved credentials.
   /// Returns an empty [Credentials] object if no credentials are found.
-  Future<Credentials> getCredentials({
-    CredentialLoginOptions? passKeyOption,
-    FetchOptionsAndroid? fetchOptions,
-  });
+  Future<Credentials> getCredentials({CredentialLoginOptions? passKeyOption, FetchOptionsAndroid? fetchOptions});
+
+  /// Prepares a later credential request so supported platforms can show the
+  /// credential selector with less latency.
+  ///
+  /// [passKeyOption] - Options for passkey login.
+  /// [fetchOptions] - Options for fetching specific types of credentials.
+  ///
+  /// Returns `true` when the platform prepared a request. Platforms that do
+  /// not support preparation return `false` and continue to work through
+  /// [getCredentials].
+  Future<bool> prepareCredentials({CredentialLoginOptions? passKeyOption, FetchOptionsAndroid? fetchOptions}) async =>
+      false;
 
   /// Retrieves the platform version information.
   ///
@@ -95,9 +101,7 @@ abstract class CredentialManagerPlatform extends PlatformInterface {
   /// [request] - The credentials to be saved.
   ///
   /// Returns a [Future] that completes with [PublicKeyCredential] representing the saved credentials.
-  Future<PublicKeyCredential> savePasskeyCredentials({
-    required CredentialCreationOptions request,
-  });
+  Future<PublicKeyCredential> savePasskeyCredentials({required CredentialCreationOptions request});
 
   /// Logs out the user.
   ///


### PR DESCRIPTION
## Summary

- expose a backward-compatible `prepareCredentials` API
- use AndroidX `prepareGetCredential` on Android 14+ and consume the matching pending handle on the next request
- fall back to the normal credential request when preparation is unsupported or a prepared handle becomes stale
- apply `preferImmediatelyAvailableCredentials` to Android `GetCredentialRequest` as well as credential creation
- serialize prepare/get options through one Dart helper and cover that contract with tests

Older Android versions and non-Android platform implementations keep their existing behavior; preparation reports `false`.

Closes #98
Closes #99

## Validation

- `flutter test packages/credential_manager_android/test/credential_manager_android_test.dart`
- `dart run melos exec --concurrency=1 -- flutter analyze`
- `./gradlew detekt`
- compiled `:credential_manager_android:compileDebugKotlin` inside a consuming Flutter app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added credential preparation for Android 14+ to help reduce account selector wait times.
  * Prepared credentials are reused during retrieval, with automatic fallback when unavailable or unsuccessful.
  * Added a cross-platform API that reports whether credential preparation is supported.

* **Documentation**
  * Updated package documentation and changelogs with credential preparation details.

* **Tests**
  * Added coverage for option forwarding, credential parsing, native calls, and unsupported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->