### PR TITLE
feat: honor allowCredentials on passkey assertion requests

### DIFF
--- a/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/Passkey/Models/LoginRequest.swift
+++ b/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/Passkey/Models/LoginRequest.swift
@@ -10,13 +10,23 @@ struct PasskeyLoginRequest {
     let rpId: String
     let userVerification: String
     let conditionalUI: Bool
+    /// Base64URL-encoded credential IDs the assertion is restricted to.
+    /// Empty means unrestricted, i.e. the WebAuthn default behaviour.
+    let allowCredentialIDs: [String]
 
     static func fromJson(_ json: [String: Any]) -> PasskeyLoginRequest {
+        // Extracting allow credential IDs properly
+        let allowCredentials = json["allowCredentials"] as? [[String: Any]] ?? []
+        let allowCredentialIDs: [String] = allowCredentials.compactMap { credential in
+            return credential["id"] as? String
+        }
+
         return PasskeyLoginRequest(
             challenge: json["challenge"] as? String ?? "",
             rpId: json["rpId"] as? String ?? "",
             userVerification: json["userVerification"] as? String ?? "",
-            conditionalUI: json["conditionalUI"] as? Bool ?? false
+            conditionalUI: json["conditionalUI"] as? Bool ?? false,
+            allowCredentialIDs: allowCredentialIDs
         )
     }
 
@@ -25,7 +35,8 @@ struct PasskeyLoginRequest {
             "challenge": challenge,
             "rpId": rpId,
             "userVerification": userVerification,
-            "conditionalUI": conditionalUI
+            "conditionalUI": conditionalUI,
+            "allowCredentials": allowCredentialIDs.map { ["id": $0] }
         ]
     }
 }

--- a/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/Passkey/PasskeyService.swift
+++ b/packages/credential_manager_ios/ios/credential_manager_ios/Sources/credential_manager_ios/Passkey/PasskeyService.swift
@@ -165,6 +165,17 @@ class PasskeyService: NSObject, ASAuthorizationControllerDelegate,
         let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
         let request = platformProvider.createCredentialAssertionRequest(challenge: challengeData)
 
+        // Restrict the credential picker to the descriptors the relying party allows.
+        // Leaving `allowedCredentials` untouched when the list is empty keeps the
+        // WebAuthn default of offering every credential registered for the rpId.
+        // `allowedCredentials` is iOS 15+ and this type is already gated to iOS 16+,
+        // so no availability check is required here.
+        if !passkeyLoginRequest.allowCredentialIDs.isEmpty {
+            request.allowedCredentials = parseCredentials(
+                credentialIDs: passkeyLoginRequest.allowCredentialIDs
+            )
+        }
+
         let con = AuthenticateController { [weak self] res in
             self?.lock.unlock()
             Self.handleAuthenticationResult(res, result: result)

--- a/packages/credential_manager_platform_interface/lib/src/models/passkey/login_pass_key_request_model.dart
+++ b/packages/credential_manager_platform_interface/lib/src/models/passkey/login_pass_key_request_model.dart
@@ -35,7 +35,7 @@ class AllowCredential {
   /// - "transports": (Optional) The transports the credential is reachable over.
   factory AllowCredential.fromJson(Map<String, dynamic> json) {
     return AllowCredential(
-      id: json['id'],
+      id: json['id'] as String,
       type: json['type'] ?? 'public-key',
       transports: (json['transports'] as List?)?.cast<String>() ?? const [],
     );
@@ -111,8 +111,14 @@ class CredentialLoginOptions {
       userVerification: json['userVerification'],
       timeout: json['timeout'] ?? 1800000,
       conditionalUI: json['conditionalUI'] ?? false,
-      allowCredentials:
-          (json['allowCredentials'] as List?)?.map((i) => AllowCredential.fromJson(i)).toList() ?? const [],
+      // Descriptors missing a String "id" are dropped rather than crashing the whole
+      // parse, matching the Swift side's compactMap over `credential["id"] as? String`.
+      allowCredentials: (json['allowCredentials'] as List?)
+              ?.cast<Map<String, dynamic>>()
+              .where((i) => i['id'] is String)
+              .map(AllowCredential.fromJson)
+              .toList() ??
+          const [],
     );
   }
 

--- a/packages/credential_manager_platform_interface/lib/src/models/passkey/login_pass_key_request_model.dart
+++ b/packages/credential_manager_platform_interface/lib/src/models/passkey/login_pass_key_request_model.dart
@@ -1,3 +1,59 @@
+/// Represents a credential that is allowed to satisfy an assertion request.
+///
+/// Mirrors the WebAuthn `PublicKeyCredentialDescriptor` entries carried in
+/// `publicKey.allowCredentials`. When the list is non-empty the authenticator
+/// must only offer credentials whose [id] appears in it.
+class AllowCredential {
+  /// The Base64URL-encoded identifier of the allowed credential.
+  ///
+  /// Kept Base64URL as received: the Android `requestJson` requires Base64URL
+  /// per the WebAuthn spec, and the iOS side decodes it with `Data.fromBase64Url`.
+  final String id;
+
+  /// The type of the allowed credential. Always `public-key` for passkeys.
+  final String type;
+
+  /// The transports the credential is reachable over, e.g. `internal`, `hybrid`.
+  final List<String> transports;
+
+  /// Constructs a new [AllowCredential] instance.
+  ///
+  /// [id] is the Base64URL-encoded identifier of the allowed credential.
+  /// [type] is the type of the allowed credential.
+  /// [transports] are the transports the credential is reachable over.
+  AllowCredential({
+    required this.id,
+    this.type = 'public-key',
+    this.transports = const [],
+  });
+
+  /// Constructs an [AllowCredential] instance from a JSON object.
+  ///
+  /// The JSON object must contain the following keys:
+  /// - "id": The Base64URL-encoded identifier of the allowed credential.
+  /// - "type": (Optional) The type of the allowed credential. Defaults to `public-key`.
+  /// - "transports": (Optional) The transports the credential is reachable over.
+  factory AllowCredential.fromJson(Map<String, dynamic> json) {
+    return AllowCredential(
+      id: json['id'],
+      type: json['type'] ?? 'public-key',
+      transports: (json['transports'] as List?)?.cast<String>() ?? const [],
+    );
+  }
+
+  /// Converts this [AllowCredential] instance to a JSON object.
+  ///
+  /// The "transports" key is omitted when empty so the resulting
+  /// `requestJson` stays minimal.
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'type': type,
+      if (transports.isNotEmpty) 'transports': transports,
+    };
+  }
+}
+
 /// Represents options for credential login.
 class CredentialLoginOptions {
   /// A challenge that the authenticator must complete.
@@ -16,6 +72,13 @@ class CredentialLoginOptions {
   /// iOS-only flag that triggers the system's conditional UI on the keyboard.
   final bool conditionalUI;
 
+  /// The credentials that are allowed to satisfy this assertion request.
+  ///
+  /// When non-empty, only credentials whose id appears in this list may be
+  /// used to sign in. An empty list imposes no restriction, which matches the
+  /// WebAuthn default of offering every credential registered for the rpId.
+  final List<AllowCredential> allowCredentials;
+
   /// Constructs a new [CredentialLoginOptions] instance.
   ///
   /// [challenge] is the challenge that the authenticator must complete.
@@ -29,6 +92,7 @@ class CredentialLoginOptions {
     required this.userVerification,
     this.timeout = 1800000,
     this.conditionalUI = false,
+    this.allowCredentials = const [],
   });
 
   /// Constructs a [CredentialLoginOptions] instance from a JSON object.
@@ -39,6 +103,7 @@ class CredentialLoginOptions {
   /// - "userVerification": Specifies whether user verification is required or preferred.
   /// - "timeout": (Optional) The time, in milliseconds, allowed for the user to complete the operation.
   ///   Defaults to 30 minutes (1800000 milliseconds).
+  /// - "allowCredentials": (Optional) The credentials allowed to satisfy the request.
   factory CredentialLoginOptions.fromJson(Map<String, dynamic> json) {
     return CredentialLoginOptions(
       challenge: json['challenge'],
@@ -46,6 +111,10 @@ class CredentialLoginOptions {
       userVerification: json['userVerification'],
       timeout: json['timeout'] ?? 1800000,
       conditionalUI: json['conditionalUI'] ?? false,
+      allowCredentials: (json['allowCredentials'] as List?)
+              ?.map((i) => AllowCredential.fromJson(i))
+              .toList() ??
+          const [],
     );
   }
 
@@ -56,6 +125,8 @@ class CredentialLoginOptions {
   /// - "rpId": The relying party identifier.
   /// - "userVerification": Specifies whether user verification is required or preferred.
   /// - "timeout": The time, in milliseconds, allowed for the user to complete the operation.
+  /// - "allowCredentials": Only present when non-empty, so an unrestricted
+  ///   request serialises exactly as it did before this field existed.
   Map<String, dynamic> toJson() {
     return {
       'challenge': challenge,
@@ -63,6 +134,8 @@ class CredentialLoginOptions {
       'userVerification': userVerification,
       'timeout': timeout,
       'conditionalUI': conditionalUI,
+      if (allowCredentials.isNotEmpty)
+        'allowCredentials': allowCredentials.map((i) => i.toJson()).toList(),
     };
   }
 }

--- a/packages/credential_manager_platform_interface/lib/src/models/passkey/login_pass_key_request_model.dart
+++ b/packages/credential_manager_platform_interface/lib/src/models/passkey/login_pass_key_request_model.dart
@@ -111,10 +111,8 @@ class CredentialLoginOptions {
       userVerification: json['userVerification'],
       timeout: json['timeout'] ?? 1800000,
       conditionalUI: json['conditionalUI'] ?? false,
-      allowCredentials: (json['allowCredentials'] as List?)
-              ?.map((i) => AllowCredential.fromJson(i))
-              .toList() ??
-          const [],
+      allowCredentials:
+          (json['allowCredentials'] as List?)?.map((i) => AllowCredential.fromJson(i)).toList() ?? const [],
     );
   }
 
@@ -134,8 +132,7 @@ class CredentialLoginOptions {
       'userVerification': userVerification,
       'timeout': timeout,
       'conditionalUI': conditionalUI,
-      if (allowCredentials.isNotEmpty)
-        'allowCredentials': allowCredentials.map((i) => i.toJson()).toList(),
+      if (allowCredentials.isNotEmpty) 'allowCredentials': allowCredentials.map((i) => i.toJson()).toList(),
     };
   }
 }

--- a/packages/credential_manager_platform_interface/test/login_pass_key_request_model_test.dart
+++ b/packages/credential_manager_platform_interface/test/login_pass_key_request_model_test.dart
@@ -1,0 +1,82 @@
+import 'package:credential_manager_platform_interface/credential_manager_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Contains both '-' and '_', and a length that is not a multiple of four, so a
+/// stray Base64URL to Base64 conversion of a credential id would be visible.
+const String _credentialId = 'test-credential_id-002';
+
+Map<String, dynamic> _requestOptions({Object? allowCredentials}) => {
+      'challenge': 'Y2hhbGxlbmdlLXZhbHVl',
+      'rpId': 'example.com',
+      'userVerification': 'preferred',
+      'timeout': 300000,
+      if (allowCredentials != null) 'allowCredentials': allowCredentials,
+    };
+
+void main() {
+  group('CredentialLoginOptions.allowCredentials', () {
+    test('defaults to an empty list when the key is absent', () {
+      final options = CredentialLoginOptions.fromJson(_requestOptions());
+
+      expect(options.allowCredentials, isEmpty);
+    });
+
+    test('stays empty when the server sends an empty list', () {
+      final options = CredentialLoginOptions.fromJson(
+        _requestOptions(allowCredentials: const []),
+      );
+
+      expect(options.allowCredentials, isEmpty);
+    });
+
+    test('serialises without the key while empty, matching the previous output',
+        () {
+      final options = CredentialLoginOptions.fromJson(_requestOptions());
+
+      expect(options.toJson(), {
+        'challenge': 'Y2hhbGxlbmdlLXZhbHVl',
+        'rpId': 'example.com',
+        'userVerification': 'preferred',
+        'timeout': 300000,
+        'conditionalUI': false,
+      });
+    });
+
+    test('parses a descriptor and keeps the id verbatim', () {
+      final options = CredentialLoginOptions.fromJson(
+        _requestOptions(allowCredentials: [
+          {
+            'id': _credentialId,
+            'type': 'public-key',
+            'transports': ['internal', 'hybrid'],
+          },
+        ]),
+      );
+
+      expect(options.allowCredentials, hasLength(1));
+      expect(options.allowCredentials.first.id, _credentialId);
+      expect(options.allowCredentials.first.type, 'public-key');
+      expect(options.allowCredentials.first.transports, ['internal', 'hybrid']);
+    });
+
+    test('serialises descriptors in the shape the platforms expect', () {
+      final options = CredentialLoginOptions.fromJson(
+        _requestOptions(allowCredentials: [
+          {'id': _credentialId, 'type': 'public-key'},
+        ]),
+      );
+
+      expect(options.toJson()['allowCredentials'], [
+        {'id': _credentialId, 'type': 'public-key'},
+      ]);
+    });
+
+    test('defaults type to public-key and omits empty transports', () {
+      final credential = AllowCredential.fromJson({'id': _credentialId});
+
+      expect(credential.type, 'public-key');
+      expect(credential.transports, isEmpty);
+      expect(credential.toJson(), {'id': _credentialId, 'type': 'public-key'});
+    });
+  });
+}

--- a/packages/credential_manager_platform_interface/test/login_pass_key_request_model_test.dart
+++ b/packages/credential_manager_platform_interface/test/login_pass_key_request_model_test.dart
@@ -77,5 +77,18 @@ void main() {
       expect(credential.transports, isEmpty);
       expect(credential.toJson(), {'id': _credentialId, 'type': 'public-key'});
     });
+
+    test('drops descriptors missing a String id instead of throwing', () {
+      final options = CredentialLoginOptions.fromJson(
+        _requestOptions(allowCredentials: [
+          {'type': 'public-key'},
+          {'id': 123},
+          {'id': _credentialId, 'type': 'public-key'},
+        ]),
+      );
+
+      expect(options.allowCredentials, hasLength(1));
+      expect(options.allowCredentials.first.id, _credentialId);
+    });
   });
 }

--- a/packages/credential_manager_platform_interface/test/login_pass_key_request_model_test.dart
+++ b/packages/credential_manager_platform_interface/test/login_pass_key_request_model_test.dart
@@ -29,8 +29,7 @@ void main() {
       expect(options.allowCredentials, isEmpty);
     });
 
-    test('serialises without the key while empty, matching the previous output',
-        () {
+    test('serialises without the key while empty, matching the previous output', () {
       final options = CredentialLoginOptions.fromJson(_requestOptions());
 
       expect(options.toJson(), {


### PR DESCRIPTION
## Problem

`publicKey.allowCredentials` tells the authenticator which credentials may satisfy an
assertion request. `CredentialLoginOptions` has no field for it, so the value a relying
party sends is dropped before it reaches the platform, and the OS offers **every**
credential registered for that `rpId`.

The user-visible effect: an account bound to a single passkey still gets a picker listing
unrelated credentials (including ones belonging to other accounts on the same device), and
can select one the server will then reject.

The field is missing at every layer, so nothing downstream can compensate:

| Layer | File | State |
|---|---|---|
| Dart model | `credential_manager_platform_interface/.../login_pass_key_request_model.dart` | no `allowCredentials` field |
| iOS model | `credential_manager_ios/.../Passkey/Models/LoginRequest.swift` | no field parsed |
| iOS native | `credential_manager_ios/.../Passkey/PasskeyService.swift` | `allowedCredentials` never set on the assertion request |

`grep -ri allowCredential` over the repo returns 0 hits outside the web JS schema.

## What this changes

- Adds `AllowCredential` (`{id, type, transports}`) and
  `CredentialLoginOptions.allowCredentials`, mirroring the `ExcludeCredential` shape the
  registration path already uses — no new abstraction.
- iOS: parses the descriptors into `PasskeyLoginRequest.allowCredentialIDs` and assigns
  `request.allowedCredentials` when the list is non-empty, reusing the existing
  `parseCredentials(credentialIDs:)` helper.

**Android and Web need no changes.** Android forwards `toJson()` verbatim into
`GetPublicKeyCredentialOption(requestJson)`, and `passkey_authenticator.js` already declares
`allowCredentials: optional([publicKeyCredentialDescriptorSchema])` with exactly the
`{type, id, transports}` shape this serialises — the web implementation was already waiting
for the field.

## Backwards compatibility

The key is serialised **only when the list is non-empty**, so an unrestricted request
produces byte-identical JSON to before this field existed. Existing callers see no change in
behaviour or payload.

Credential ids are passed through as Base64URL, deliberately:

- the Android `requestJson` requires Base64URL per the WebAuthn spec
- the iOS side decodes with `Data.fromBase64Url`

## iOS availability

No `#available` guard is added. `allowedCredentials` on
`ASAuthorizationPlatformPublicKeyCredentialAssertionRequest` is `API_AVAILABLE(ios(15.0))`,
and `PasskeyService` is already `@available(iOS 16.0, *)`. This is different from the
registration path's `excludedCredentials`, which genuinely needs `iOS 17.4`.

## Testing

`packages/credential_manager_platform_interface/test/` — 6 tests covering the three inputs a
server can send (key absent / empty list / one descriptor), asserting that the serialised
payload is unchanged when the list imposes no restriction.

```
$ flutter test packages/credential_manager_platform_interface/test
00:03 +6: All tests passed!

$ flutter analyze packages/credential_manager_platform_interface/lib \
                  packages/credential_manager_platform_interface/test
No issues found!
```

Also verified end to end on iOS 16+ and Android 14+ hardware: the picker now lists only the
credential the server allowed.

## Notes

I left CHANGELOG entries and version bumps out of this PR so they can follow your release
process — happy to add them in whatever form you prefer.

---

Based on `main`, since that is where the currently published packages come from and the
files this touches are identical there. Happy to retarget at `develop` if that suits your
release flow better — just say so and I will rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying allowed passkey credentials during login.
  * Passkey authentication now limits credential choices to those provided by the relying party.
  * Added parsing and serialization for credential IDs, types, and transport details.

* **Bug Fixes**
  * Preserved credential IDs exactly as provided, including special characters and varying lengths.

* **Tests**
  * Added coverage for default, empty, parsing, and serialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->