### PR TITLE
fix: compile against androidx.credentials 1.6.0 to avoid NoSuchMethodError

### DIFF
--- a/packages/credential_manager_android/android/build.gradle
+++ b/packages/credential_manager_android/android/build.gradle
@@ -77,10 +77,10 @@ dependencies {
     detektPlugins 'io.gitlab.arturbosch.detekt:detekt-formatting:1.23.7'
     implementation 'androidx.annotation:annotation:1.9.1'
     //jetpack credential Manager
-    implementation "androidx.credentials:credentials:1.5.0"
+    implementation "androidx.credentials:credentials:1.6.0"
     // optional - needed for credentials support from play services, for devices running
     // Android 13 and below.
-    implementation "androidx.credentials:credentials-play-services-auth:1.5.0"
+    implementation "androidx.credentials:credentials-play-services-auth:1.6.0"
     //For google sign in
     implementation "com.google.android.libraries.identity.googleid:googleid:1.1.1"
     //Co-routine


### PR DESCRIPTION
## Problem

Creating a passkey crashes at runtime in any app that also depends on `google_sign_in`:

```
java.lang.NoSuchMethodError: No direct method <init>(Ljava/lang/String;[BZLjava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
  in class Landroidx/credentials/CreatePublicKeyCredentialRequest;
    at com.smkwinner.cred_manager.credential_manager.CredentialManagerUtils.savePasskeyCredentials(CredentialManagerUtils.kt:494)
    at com.smkwinner.cred_manager.credential_manager.CredentialManagerPlugin.handleSavePublicKeyCredential(CredentialManagerPlugin.kt:198)
```

## Root cause

`credential_manager_android` declares `androidx.credentials:credentials:1.5.0`.
`google_sign_in_android` (7.2.11) declares `1.6.0`. Gradle unifies the app's runtime
classpath to the highest requested version, so the app **runs** against 1.6.0 while this
module still **compiles** against 1.5.0.

1.6.0 added a parameter to `CreatePublicKeyCredentialRequest`, which changed the synthetic
default-args constructor. Comparing the two with `javap`:

| Version | Default-args constructor |
|---|---|
| 1.5.0 | `(String, byte[], boolean, String, boolean, int, DefaultConstructorMarker)` |
| 1.6.0 | `(String, byte[], boolean, String, boolean, **boolean**, int, DefaultConstructorMarker)` |

The call `CredentialManagerUtils.kt:494` emits against 1.5.0 therefore does not exist at
runtime. Confirmed by disassembling the built APK with `dexdump`: the single emitted call
site carries the 1.5.0 signature.

## Fix

Bump the declared version to 1.6.0 so the module compiles against the version it will run
on. The Kotlin source needs no change — every `androidx.credentials` type this module
imports is present in 1.6.0, and the build passes as is.

`googleid` is deliberately left at 1.1.1: every `Builder` method used here
(`setServerClientId`, `setFilterByAuthorizedAccounts`, `setAutoSelectEnabled`, `setNonce`,
`build`, and `GetSignInWithGoogleOption.Builder(String)`) is unchanged between 1.1.1 and
1.2.0, so it has no equivalent ABI break.

## Workaround for anyone hitting this before a release

Forcing the version in the app's root `build.gradle` fixes both classpaths, because
`allprojects` covers the plugin subproject's compile classpath too:

```gradle
allprojects {
    configurations.configureEach {
        resolutionStrategy.eachDependency { details ->
            if (details.requested.group == 'androidx.credentials') {
                details.useVersion '1.6.0'
            }
        }
    }
}
```

---

Based on `main`, since that is where the currently published packages come from and the
files this touches are identical there. Happy to retarget at `develop` if that suits your
release flow better — just say so and I will rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android Credential Manager integration to use the latest supported library version.
  * Improved compatibility for credential sign-in flows, including devices running Android 13 and earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->