### PR TITLE
chore: release v5.0.0 (credential_manager) / v4.0.0 (platform_interface, android, ios) / v2.3.0 (web)

### DIFF
--- a/docSite/src/pages/ApiReferencePage.tsx
+++ b/docSite/src/pages/ApiReferencePage.tsx
@@ -80,6 +80,10 @@ const ApiReferencePage = () => {
             <td className="border border-gray-300 px-4 py-2">Retrieves stored credentials based on provided options.</td>
           </tr>
           <tr>
+            <td className="border border-gray-300 px-4 py-2 font-mono text-sm">prepareCredentials()</td>
+            <td className="border border-gray-300 px-4 py-2">Prefetches a matching credential request ahead of time on Android 14+, so a following <code>getCredentials()</code> call can resolve instantly; returns <code>false</code> on unsupported platforms.</td>
+          </tr>
+          <tr>
             <td className="border border-gray-300 px-4 py-2 font-mono text-sm">logout()</td>
             <td className="border border-gray-300 px-4 py-2">Clears saved credentials from session (Android only).</td>
           </tr>
@@ -103,8 +107,13 @@ const ApiReferencePage = () => {
       <p className="mb-4">Class for configuring passkey creation options.</p>
       
       <h3 className="text-xl font-semibold mt-6 mb-2">CredentialLoginOptions</h3>
-      
-      <p className="mb-4">Class for configuring passkey authentication options.</p>
+
+      <p className="mb-4">
+        Class for configuring passkey authentication options. Accepts an optional <code>allowCredentials</code> list
+        of <code>AllowCredential</code> descriptors (<code>id</code>, <code>type</code>, <code>transports</code>) to
+        restrict which passkey the OS offers for the assertion, instead of showing every passkey registered for the
+        relying party.
+      </p>
       
       <h3 className="text-xl font-semibold mt-6 mb-2">FetchOptionsAndroid</h3>
       

--- a/docSite/src/pages/ChangelogPage.tsx
+++ b/docSite/src/pages/ChangelogPage.tsx
@@ -6,6 +6,43 @@
 
 const changelog = [
   {
+    version: "5.0.0",
+    items: [
+      <>Bumped <code>credential_manager_platform_interface</code>, <code>credential_manager_android</code>, and <code>credential_manager_ios</code> to <code>^4.0.0</code>, and <code>credential_manager_web</code> to <code>^2.3.0</code>.</>,
+      <>Added <code>prepareCredentials</code>, which prefetches a matching Android credential request on Android 14 and newer (returns <code>false</code> on unsupported platforms) — pairs with <code>getCredentials</code>, which now consumes the prepared handle automatically and falls back to a normal request if it can no longer be used.</>,
+      <><code>CredentialLoginOptions</code> now accepts <code>allowCredentials</code>, letting a relying party restrict which passkey the OS offers for a WebAuthn assertion, instead of showing every passkey registered for the rpId.</>,
+      "No breaking changes to this package's own public Dart API.",
+    ],
+  },
+  {
+    version: "4.3.0",
+    items: [
+      "Republished 4.2.0's contents with a clean example/ directory (packaging fix only, no functional or API changes).",
+    ],
+  },
+  {
+    version: "4.2.0",
+    items: [
+      <>Bumped <code>credential_manager_ios</code> to <code>^3.2.0</code>, fixing an issue where passkey registration/authentication could silently hang forever on iOS.</>,
+      "No breaking changes to this package's own public Dart API.",
+    ],
+  },
+  {
+    version: "4.1.0",
+    items: [
+      <>Fixed a critical issue in 4.0.0: it depended on a <code>credential_manager_platform_interface</code> version that predated the <code>nonce</code> parameter its Google Sign-In call relies on, breaking <code>flutter pub get</code>/analysis for anyone resolving from pub.dev.</>,
+      <>Bumped <code>credential_manager_android</code> and <code>credential_manager_ios</code> to <code>^3.1.0</code>, and <code>credential_manager_web</code> to <code>^2.2.0</code>.</>,
+      "No breaking changes to this package's own public Dart API.",
+    ],
+  },
+  {
+    version: "4.0.0",
+    items: [
+      <><strong>New: Web platform support.</strong> Adds <code>credential_manager_web</code>, bringing passkey (WebAuthn), password credential, and Google Sign-In (GIS/FedCM) support to Flutter Web.</>,
+      "No breaking changes to the existing Android/iOS Dart API.",
+    ],
+  },
+  {
     version: "3.0.1",
     items: [
       <>Bumped <code>credential_manager_ios</code> to <code>^3.0.1</code> and <code>credential_manager_android</code> to <code>^3.0.1</code>, both of which add native static analysis (SwiftLint, Detekt) with no functional or API changes.</>,

--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-# Unreleased
+# 5.0.0
+- Bumped `credential_manager_platform_interface` to `^4.0.0`, `credential_manager_android` to `^4.0.0`,
+  `credential_manager_ios` to `^4.0.0`, and `credential_manager_web` to `^2.3.0`
 - Added `prepareCredentials`, which prefetches a matching Android credential request on Android 14 and newer and
-  returns `false` on unsupported platforms.
+  returns `false` on unsupported platforms
+- `CredentialLoginOptions` now accepts `allowCredentials`, letting a relying party restrict which passkey the OS
+  offers for a WebAuthn assertion — see `credential_manager_platform_interface` and `credential_manager_ios`
+  CHANGELOGs for details
+- No breaking changes to this package's own public Dart API
 
-# 4.3.0
+## 4.3.0
 - Republishes 4.2.0's contents with a clean `example/` directory. 4.2.0's published archive
   accidentally included 4 locally-modified-but-uncommitted `example/ios/` files (Xcode-project d
   migration churn from local tooling, not a deliberate change) instead of what's committed to

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Credential Manager plugin. Provides one-tap login functionality and stores credentials
   in the user's Google account on Android and in the Keychain on iOS.
 
-version: 4.3.0
+version: 5.0.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 
@@ -16,10 +16,10 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  credential_manager_platform_interface: ^3.0.0
-  credential_manager_android: ^3.2.0
-  credential_manager_ios: ^3.2.0
-  credential_manager_web: ^2.2.0
+  credential_manager_platform_interface: ^4.0.0
+  credential_manager_android: ^4.0.0
+  credential_manager_ios: ^4.0.0
+  credential_manager_web: ^2.3.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/credential_manager_android/CHANGELOG.md
+++ b/packages/credential_manager_android/CHANGELOG.md
@@ -1,9 +1,16 @@
-# Unreleased
+# 4.0.0
+- Bumped `credential_manager_platform_interface` to `^4.0.0` (required for `prepareCredentials` and
+  `allowCredentials`)
 - `getCredentials` now applies the `preferImmediatelyAvailableCredentials` value supplied during initialization.
-- Added Android 14+ credential preparation. A matching `getCredentials` call consumes the prepared handle and falls
-  back to the normal request if the prefetched data can no longer be used.
+- Added Android 14+ credential preparation: a new `prepareCredentials` call prefetches a matching credential
+  request ahead of time. A matching `getCredentials` call consumes the prepared handle and falls back to the
+  normal request if the prefetched data can no longer be used.
+- Fixed compiling against `androidx.credentials` 1.6.0: apps that also depend on `google_sign_in` (which pulls
+  in 1.6.0) no longer crash with `NoSuchMethodError` when creating a passkey, since Gradle unifies the runtime
+  classpath to the highest requested version.
+- No breaking changes to the public Dart API.
 
-# 3.1.0
+## 3.1.0
 - Bumped `credential_manager_platform_interface` to `^3.0.0` (required — the previously-declared
   `^2.0.8` resolves to a published version that predates the `nonce` parameter this package's
   `saveGoogleCredential` override already relies on)

--- a/packages/credential_manager_android/pubspec.yaml
+++ b/packages/credential_manager_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: credential_manager_android
 description: Android implementation of the credential_manager plugin using Jetpack Credential Manager API.
-version: 3.2.0
+version: 4.0.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 environment:
@@ -10,7 +10,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  credential_manager_platform_interface: ^3.0.0
+  credential_manager_platform_interface: ^4.0.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/credential_manager_ios/CHANGELOG.md
+++ b/packages/credential_manager_ios/CHANGELOG.md
@@ -1,4 +1,12 @@
-# 3.2.0
+# 4.0.0
+- Bumped `credential_manager_platform_interface` to `^4.0.0` (required for `allowCredentials`)
+- Honor `allowCredentials` on passkey assertion requests: parses the WebAuthn `allowCredentials`
+  descriptors into `PasskeyLoginRequest.allowCredentialIDs` and assigns `request.allowedCredentials`
+  when non-empty, so the OS only offers credentials the relying party allows instead of every passkey
+  registered for the rpId
+- No breaking changes to the public Dart API
+
+## 3.2.0
 - **Fixes #92: passkey registration/authentication silently hangs since 3.0.1.** `savePassKeyCredentials`
   and `getPasskeyCredentials` created `PasskeyService` as a local variable with no strong reference
   held anywhere; once the enclosing method returned, it deallocated immediately. Since

--- a/packages/credential_manager_ios/pubspec.yaml
+++ b/packages/credential_manager_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: credential_manager_ios
 description: iOS implementation of the credential_manager plugin using Keychain and Autofill.
-version: 3.2.0
+version: 4.0.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose$
 
@@ -13,7 +13,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  credential_manager_platform_interface: ^3.0.0
+  credential_manager_platform_interface: ^4.0.0
   cbor: ^6.3.5
 
 dev_dependencies:

--- a/packages/credential_manager_platform_interface/CHANGELOG.md
+++ b/packages/credential_manager_platform_interface/CHANGELOG.md
@@ -1,7 +1,15 @@
-# Unreleased
-- Added a backward-compatible `prepareCredentials` platform hook that defaults to `false` on unsupported platforms.
+# 4.0.0
+- Added `AllowCredential` (`{id, type, transports}`) and `CredentialLoginOptions.allowCredentials`,
+  letting a relying party restrict which passkey the OS offers for a WebAuthn assertion. Previously
+  the field was dropped before reaching the platform, so an account bound to a single passkey still
+  showed a picker listing every credential registered for the rpId.
+- `CredentialLoginOptions.fromJson` now filters out `allowCredentials` entries whose `id` is missing
+  or not a `String` instead of throwing and failing the entire parse.
+- Added a backward-compatible `prepareCredentials` platform hook that defaults to `false` on
+  unsupported platforms, enabling Android 14+ credential prefetching.
+- No breaking changes to the public Dart API.
 
-# 3.0.0
+## 3.0.0
 - **Breaking:** `CredentialManagerPlatform.saveGoogleCredential` gains an optional named `{String?
   nonce}` parameter. This was actually added in a prior commit without a version bump — the
   package published as `2.0.8` on pub.dev predates this change and does not have `nonce`, which

--- a/packages/credential_manager_platform_interface/pubspec.yaml
+++ b/packages/credential_manager_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: credential_manager_platform_interface
 description: A common platform interface for the credential_manager plugin. This package allows platform-specific implementations of credential_manager to share the same interface.
 
-version: 3.0.0
+version: 4.0.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 

--- a/packages/credential_manager_web/CHANGELOG.md
+++ b/packages/credential_manager_web/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 2.2.0
+# 2.3.0
+- Bumped `credential_manager_platform_interface` to `^4.0.0` (required by its new `prepareCredentials`
+  and `allowCredentials` additions). No functional changes here: this package's JS bridge already
+  accepted an `allowCredentials` descriptor list, and there is no browser equivalent of Android's
+  credential prefetch to implement.
+
+## 2.2.0
 - Bumped `credential_manager_platform_interface` to `^3.0.0` (required — the previously-declared
   `^2.0.8` resolves to a published version that predates the `nonce` parameter this package's
   `saveGoogleCredential` override already relies on)

--- a/packages/credential_manager_web/pubspec.yaml
+++ b/packages/credential_manager_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: credential_manager_web
 description: Web implementation of the credential_manager plugin using Web Authentication API (WebAuthn) and Credential Management API.
-version: 2.2.0
+version: 2.3.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 environment:
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  credential_manager_platform_interface: ^3.0.0
+  credential_manager_platform_interface: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
Promotes `develop` to `main` to prepare pub.dev publishing. This brings in everything merged into `develop` since the last promotion, headlined by PR #104:

- New feature: `prepareCredentials` — prefetches a matching Android 14+ credential request ahead of time, consumed automatically by a following `getCredentials()` call.
- New feature: `CredentialLoginOptions.allowCredentials` — lets a relying party restrict which passkey the OS offers for a WebAuthn assertion (`credential_manager_platform_interface` + `credential_manager_ios`).
- Also folds in two previously-unreleased fixes: compiling against `androidx.credentials` 1.6.0 (avoids a `NoSuchMethodError` crash alongside `google_sign_in`), and dropping malformed `allowCredentials` descriptors instead of throwing.
- Version bumps: `credential_manager_platform_interface`/`credential_manager_android`/`credential_manager_ios` 3.x → **4.0.0**, `credential_manager_web` 2.2.0 → **2.3.0**, `credential_manager` (umbrella) 4.3.0 → **5.0.0**.
- CHANGELOGs and docs site (`ChangelogPage.tsx`, `ApiReferencePage.tsx`) updated accordingly.

## Test plan
- [x] `make check` (format-check + analyze + SwiftLint + Detekt) — clean
- [x] `docSite`: `npm run build` succeeds
- [x] PR #104 CI: Android build/lint, iOS build/lint, Dart format/analyze, Web build, Docs site build — all pass (cla/google failed but develop has no branch protection requiring it; merged with explicit owner go-ahead)
- [x] Local multi-specialist AI PR review (security/tests/hygiene/android/ios/web) — 0 findings
- [ ] Human review + merge into `main`
- [ ] `flutter pub publish --dry-run` per package in dependency order, then real publish with per-package confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added credential preparation on Android 14+ so subsequent credential retrieval can resolve instantly when supported.
  - Added `allowCredentials` support to restrict passkey options during sign-in on supported platforms.
  - Added Flutter Web platform support.
- **Bug Fixes**
  - Fixed an iOS passkey assertion issue and Android compatibility with newer credential libraries.
  - Improved handling of incomplete credential descriptors without errors.
- **Documentation**
  - Updated API references and changelogs for the latest 5.0.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->