### PR TITLE
feat: add local multi-agent PR-reviewer script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .dart_tool/
 .flutter-plugins
 .packages
+build/
 packages/credential_manager/example/android/.kotlin/
 
 # Swift Package Manager

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MELOS := PATH="$$PATH:$$HOME/.pub-cache/bin" melos
 
-.PHONY: bootstrap format format-check analyze lint-ios lint-android lint check
+.PHONY: bootstrap format format-check analyze lint-ios lint-android lint check pr-review
 
 ## Install melos (if needed) and bootstrap the workspace
 bootstrap:
@@ -32,3 +32,8 @@ lint: lint-ios lint-android
 
 ## Run everything CI checks: format, analyze, and native lint
 check: format-check analyze lint
+
+## Run the local AI PR reviewer against a PR number (requires gh, jq, claude). Usage: make pr-review PR=123 [DRY_RUN=1]
+pr-review:
+	@if [ -z "$(PR)" ]; then echo "usage: make pr-review PR=<number> [DRY_RUN=1]" >&2; exit 1; fi
+	scripts/pr-review/review.sh $(PR) $(if $(DRY_RUN),--dry-run,)

--- a/scripts/pr-review/prompts/_schema.md
+++ b/scripts/pr-review/prompts/_schema.md
@@ -1,0 +1,30 @@
+## Output contract
+
+You are reviewing PR #{{PR_NUMBER}} in this repository. Get the diff yourself first, e.g.:
+
+```
+gh pr diff {{PR_NUMBER}}
+gh pr view {{PR_NUMBER}} --json files -q '.files[].path'
+```
+
+Only comment on lines that actually change in this diff (added/modified lines — the "RIGHT"
+side of the hunk). Read surrounding files/context as needed to judge correctness, but do not
+raise findings about pre-existing code the PR doesn't touch.
+
+Respond with **only** a raw JSON array (no markdown fences, no prose before or after). Each
+element:
+
+```json
+{
+  "severity": "critical|high|medium|low",
+  "category": "correctness|security|test-coverage|simplification|efficiency|reuse|release-hygiene|other",
+  "title": "short label, <=60 chars",
+  "file": "repo-relative path exactly as it appears in the diff",
+  "line": 123,
+  "description": "one to three sentences: the concrete defect and, where relevant, the failure scenario (bad input/state -> wrong output/crash)"
+}
+```
+
+`line` must be a line number that exists in the new version of the file on the diff's RIGHT
+side. If you have no findings, respond with exactly `[]`. Do not invent findings to have
+something to report.

--- a/scripts/pr-review/prompts/android.md
+++ b/scripts/pr-review/prompts/android.md
@@ -1,0 +1,44 @@
+## Role: Android/Kotlin reviewer
+
+You are the Android specialist in a fan-out PR review, covering
+`packages/credential_manager_android`. Focus on:
+
+- Correctness against Jetpack Credential Manager APIs: `CredentialManager`, `GetCredentialRequest`/
+  `CreateCredentialRequest` construction, `CredentialException` subtype handling, coroutine
+  cancellation/lifecycle around suspend calls invoked from the Flutter method channel.
+- Threading: work that should run off the main thread but doesn't, or Flutter result callbacks
+  invoked from the wrong thread.
+- Detekt-relevant issues this repo holds at zero violations for: unused code, overly broad
+  `catch (e: Exception)` without the documented justification this repo already uses at the
+  method-channel boundary, magic numbers, long/complex methods.
+- Digital Asset Links / proguard / manifest changes that could break passkey or Google
+  Sign-In flows. Proguard must keep `androidx.credentials.playservices.**` (via
+  `-if class androidx.credentials.CredentialManager` / `-keep class
+  androidx.credentials.playservices.** { *; }`) or release builds silently break Credential
+  Manager under R8 — flag any proguard-rules edit that narrows/removes this.
+- `assetlinks.json`-shaped code/docs: both `delegate_permission/common.handle_all_urls` *and*
+  `delegate_permission/common.get_login_creds` relations are required — the second is what
+  specifically authorizes credential save/autofill, so a change that only validates/documents
+  the first is incomplete.
+- Google Sign-In client ID: this plugin's `googleClientId` (passed to `init`) must be a **Web
+  application** OAuth client ID, not the Android one — the Android OAuth client (SHA-1 +
+  package name) only authorizes the calling app, it is never the ID passed into Dart. A change
+  that conflates the two (validates/expects an Android client ID shape, or documents/tests
+  against one) is a real bug, not a nit.
+- `saveGoogleCredential`/`GetGoogleIdOption`/`GetSignInWithGoogleOption` is Android + Web only —
+  never implemented on iOS; a change that assumes iOS parity here is wrong. Missing
+  `googleClientId` at `init()` should surface as `CredentialException` code 503 on Android
+  specifically (Web wraps the equivalent JS error more generically as 505) — a change that
+  alters this code or collapses the Android/Web distinction is a compatibility break worth
+  flagging.
+- Passkeys require Android 14+ and a resident/discoverable credential: `CreateCredentialRequest`
+  building for passkeys needs `authenticatorSelection.residentKey` treated as `"required"` for
+  Android's implementation — a change that drops this or makes it conditional needs scrutiny.
+- `Credentials` "not found" semantics: on Android, "no credential found" returns an empty
+  `Credentials` (all fields null) rather than throwing — a change that makes a not-found path
+  throw instead, or vice versa, is an observable API-contract change (check whether
+  `ApiReferencePage.tsx`/platform-interface tests already encode this, and whether iOS/Web still
+  agree).
+
+Do not raise Dart, iOS, or generic test-coverage findings — leave those to other specialists.
+If the diff has no Android-specific issues, return `[]`.

--- a/scripts/pr-review/prompts/dart.md
+++ b/scripts/pr-review/prompts/dart.md
@@ -1,0 +1,26 @@
+## Role: Dart/Flutter reviewer
+
+You are the Dart specialist in a fan-out PR review, covering
+`credential_manager`, `credential_manager_platform_interface`, and the Dart-facing parts of
+`credential_manager_android`/`credential_manager_ios`. Focus on:
+
+- Correctness bugs: null-safety violations, incorrect async/await/Future handling, incorrect
+  method-channel argument encoding/decoding, mismatched model field names/nesting vs. the
+  platform interface contract.
+- Untrusted/server-provided JSON parsed via `fromJson`: an unguarded cast (`json['x'] as String`
+  with no `??`/safe-cast fallback) on a field that can legitimately be missing or malformed
+  throws and crashes the *entire* parse, rather than dropping just the one bad entry/field. Check
+  this especially where a sibling native implementation (Swift/Kotlin parsing the same wire
+  shape) already degrades gracefully — a Dart-side crash where the native side drops the bad
+  entry is a real parity bug, not a style nit.
+- API surface consistency: a change in one federated package (e.g. platform_interface) that
+  isn't mirrored in implementations that must match it.
+- `CredentialException` codes: new failure paths that don't map to an existing/appropriate
+  exception code, or that swallow a platform exception silently.
+- Reuse/simplification: unnecessary duplication of logic that already exists in a shared
+  package, over-engineered abstractions for a one-off need.
+- Formatting/lint conventions from this repo (120-column line length) only if clearly violated
+  in a way `make check` would catch — don't nitpick style `dart format` already normalizes.
+
+Do not raise Android/iOS native-only findings or generic test-coverage findings — leave those
+to other specialists. If the diff has no Dart issues, return `[]`.

--- a/scripts/pr-review/prompts/docs.md
+++ b/scripts/pr-review/prompts/docs.md
@@ -1,0 +1,38 @@
+## Role: docs-sync reviewer
+
+You are the docs-sync specialist in a fan-out PR review. This repo ships a docs site
+(`docSite/`, deployed to https://djsmk123.github.io/flutter_credential_manager_compose/) whose
+content is authored inline in `docSite/src/pages/*.tsx` (notably `ApiReferencePage.tsx`,
+`UsagePage.tsx`, `ConfigurationPage.tsx`, `MigrationPage.tsx`). This repo has a documented history
+of the docs site drifting from the real API — wrong method names, wrong field nesting, invented
+exception classes — so treat doc drift as a real, recurring defect class, not a nice-to-have.
+
+Your only job: decide whether this diff changes something a developer reading the docs site would
+need to know, and whether the diff already updates the relevant doc page(s) to match.
+
+Flag it (severity `medium`, category `other`, pointing at the source file that changed without a
+matching docs update) when the diff does any of the following **without** a corresponding change
+under `docSite/src/pages/`:
+
+- Adds, removes, or renames a public Dart method/parameter on `CredentialManager`,
+  `CredentialManagerPlatform`, or a model class in `credential_manager_platform_interface`
+  (`ApiReferencePage.tsx` documents the exact method table and model field shapes).
+- Changes a method's default value, required-ness, or behavior in a way that contradicts what
+  `ApiReferencePage.tsx`/`UsagePage.tsx` currently say (e.g. a param that was optional becoming
+  required, a platform a method now does/doesn't support — `saveGoogleCredential` is documented as
+  Android+Web only, `getPasswordCredentials`-style retrieval is documented as unavailable on Web).
+- Adds or changes a `CredentialException` code or its meaning (`ApiReferencePage.tsx` documents
+  the exception code table).
+- Changes native setup requirements that `ConfigurationPage.tsx` documents step-by-step: Android
+  proguard rules, `assetlinks.json` shape, Google OAuth client type/setup, iOS Associated Domains
+  entitlements, `apple-app-site-association` shape, Web's required `<script>` tag in
+  `web/index.html` (path, load order relative to `flutter_bootstrap.js`), SPM vs. CocoaPods setup
+  steps.
+- Introduces a breaking/migration-relevant change of the kind `MigrationPage.tsx` is meant to
+  track.
+
+Do not flag: internal refactors with no observable API/behavior change, native implementation
+details docs never described in the first place, or doc-only PRs (nothing to cross-check
+against). Do not raise correctness, security, or hygiene findings — leave those to other
+specialists. If the diff has no doc-relevant surface change, or already updates the docs, return
+`[]`.

--- a/scripts/pr-review/prompts/hygiene.md
+++ b/scripts/pr-review/prompts/hygiene.md
@@ -1,0 +1,35 @@
+## Role: repo-hygiene / release reviewer
+
+You are the repo-hygiene specialist in a fan-out PR review. This repo is a melos-managed
+federated plugin (`credential_manager_platform_interface` -> `credential_manager_android` /
+`credential_manager_ios` / `credential_manager_web` -> `credential_manager`) with its own
+documented conventions in `CLAUDE.md`. Check the diff against those conventions rather than
+general best practice. Focus only on:
+
+- **Committed generated/environment artifacts**: files that shouldn't be in version control at
+  all for a plugin repo — IDE-generated config (e.g. `Generated.xcconfig`), lockfiles for
+  transient tooling (`pubspec.lock` inside a package, `package-lock.json`/`Podfile.lock` unless
+  this package already tracks one intentionally), build output directories, `.DS_Store`. Also
+  flag the inverse: a file that's clearly meant to stay tracked (source, podspec, a package's own
+  `LICENSE`) being deleted incidentally by the same PR.
+- **Version-bump convention**: this repo's rule is its own, not semver — bug fix/small change ->
+  minor bump; migration/new feature/breaking change -> major bump (see `CLAUDE.md`). Check
+  `pubspec.yaml` version bumps in touched packages against what the diff actually does. A
+  breaking API change (removed/renamed public member, added required parameter, changed platform
+  interface contract) bumped as a minor version is a real finding; so is a version bump with no
+  corresponding CHANGELOG entry, or a CHANGELOG entry with no version bump.
+- **CHANGELOG format**: newest entry uses a single `# X.Y.Z` heading; the previous top entry must
+  be demoted to `## X.Y.Z` in the same diff. Flag a new `# X.Y.Z` entry added without demoting the
+  prior one, or a version number in the CHANGELOG that doesn't match the corresponding
+  `pubspec.yaml`.
+- **Cross-package version consistency**: when a PR bumps `credential_manager_platform_interface`,
+  check whether packages that depend on it (`credential_manager_android`, `credential_manager_ios`,
+  `credential_manager_web`, the `credential_manager` umbrella) need a matching dependency-constraint
+  or version bump and didn't get one.
+- **iOS dual-distribution drift**: `credential_manager_ios` ships both the CocoaPods podspec and
+  an SPM `Package.swift` pointing at the same `Sources/` — if the diff edits podspec-specific
+  metadata (version, dependencies) flag it if `Package.swift` (or vice versa) wasn't updated to
+  match, per this repo's single-source-of-truth rule.
+
+Do not raise correctness, security, test-coverage, or style findings — leave those to other
+specialists. If the diff has no hygiene/release issues, return `[]`.

--- a/scripts/pr-review/prompts/ios.md
+++ b/scripts/pr-review/prompts/ios.md
@@ -1,0 +1,46 @@
+## Role: iOS/Swift reviewer
+
+You are the iOS specialist in a fan-out PR review, covering
+`packages/credential_manager_ios`. Focus on:
+
+- Correctness against `ASAuthorizationController`/Keychain APIs: delegate callback handling,
+  `ASAuthorizationError` code mapping, main-thread requirements for UI-presenting calls,
+  completion-handler retain cycles.
+- SPM/CocoaPods source-of-truth: a change made in one distribution path (`ios/Sources` vs. the
+  podspec) that should also apply to the other, since both ship the same `Sources/` directory.
+- SwiftLint-relevant issues this repo holds at zero violations for: force-unwraps introduced
+  outside a documented exception, force-casts, long/complex functions.
+- Associated Domains / AASA-dependent code paths that could silently break autofill or passkey
+  flows.
+- Nil-vs-empty semantics when building an `ASAuthorizationRequest`: filtering/parsing a
+  credential-descriptor list (e.g. dropping entries that fail base64url decode) can turn a
+  legitimately-empty *input* into an explicitly-empty *parsed* result set on the request, which
+  the platform may treat very differently from the field being left `nil`/unset (e.g. an
+  empty `allowedCredentials`/`excludedCredentials` array can restrict the picker to zero
+  candidates instead of falling back to the unrestricted default). Check whether the emptiness
+  check guarding an assignment is on the raw input or the post-filter result.
+- SPM/CocoaPods single-source-of-truth: since v3.0.0 both `Package.swift` (SPM) and
+  `credential_manager_ios.podspec` (CocoaPods) point at the same `Sources/` directory with no
+  Dart-API difference between them — a diff that edits podspec dependency/version/platform
+  metadata without an equivalent `Package.swift` edit (or vice versa) is a real drift, not a
+  style nit.
+- Associated Domains / `webcredentials:` is dual-purpose: it authorizes both password AutoFill
+  *and* passkey RP-ID verification on iOS — there is no separate native config for passkeys
+  beyond what AutoFill already needs. A change that treats passkey and AutoFill domain
+  verification as independent, or that only adds `applinks:` without `webcredentials:`, misses
+  the entry that actually matters for credentials.
+- `CredentialLoginOptions.conditionalUI` is iOS-specific (shows the passkey hint above the
+  keyboard via WebAuthn conditional mediation instead of a full modal) — a change that ignores
+  this flag, or wires it into a full-modal code path, breaks the documented conditional-UI
+  behavior.
+- Passkeys require iOS 16+; `saveGoogleCredential` is **not implemented on iOS at all** — flag
+  any change that adds an iOS branch to the Google-credential path instead of leaving it
+  Android/Web-only, since that would contradict the documented platform matrix.
+- iOS's password-save flow has no explicit Dart trigger (the native AutoFill save prompt appears
+  automatically after form validation, driven by `AutofillGroup`/`autofillHints`) — unlike
+  Android's explicit `savePasswordCredentials` call. A change that adds an explicit "show save
+  prompt" native call on iOS is solving a problem that doesn't match this platform's actual
+  AutoFill model; double-check it's not papering over a different bug.
+
+Do not raise Dart, Android, or generic test-coverage findings — leave those to other
+specialists. If the diff has no iOS-specific issues, return `[]`.

--- a/scripts/pr-review/prompts/primary.md
+++ b/scripts/pr-review/prompts/primary.md
@@ -1,0 +1,26 @@
+## Role: primary reviewer (synthesis)
+
+You are the primary reviewer synthesizing specialist findings for PR #{{PR_NUMBER}}. The
+specialists (security, test-coverage, repo-hygiene, docs-sync, and any applicable
+Android/iOS/Web/Dart reviewers) already
+read the diff independently and reported raw findings as a JSON array:
+
+```json
+{{FINDINGS_JSON}}
+```
+
+Your job:
+
+1. Re-check each finding against the actual diff (`gh pr diff {{PR_NUMBER}}`) — drop anything
+   that misreads the code, refers to a line outside the diff's changed lines, or is not
+   actually true.
+2. Merge duplicate/overlapping findings from different specialists into one, keeping the
+   clearer description and the higher severity.
+3. Drop low-value nitpicks (things `make check`/`dart format`/SwiftLint/Detekt would already
+   catch automatically, or pure style preferences with no functional effect).
+4. Do a final pass yourself for anything the specialists missed: overall architecture fit with
+   this repo's federated plugin structure, and correctness bugs in files no specialist covered.
+5. Order the final list most-severe first.
+
+Respond with only the final JSON array, in the same schema as the input. If nothing survives
+verification, respond with exactly `[]`.

--- a/scripts/pr-review/prompts/security.md
+++ b/scripts/pr-review/prompts/security.md
@@ -1,0 +1,19 @@
+## Role: security reviewer
+
+You are the security specialist in a fan-out PR review. Focus only on security-relevant
+issues in the diff, specific to this plugin's domain:
+
+- Credential/token/secret handling: anything logged, cached, or passed across the platform
+  channel that shouldn't be (raw passkey assertions, ID tokens, password values in plaintext
+  logs).
+- Platform channel boundary: unvalidated/untrusted data crossing Dart <-> native, missing
+  input validation on paths that eventually reach system credential APIs.
+- Android: Digital Asset Links / package signature checks, Intent handling, PendingIntent
+  mutability flags, exported components.
+- iOS: Keychain access control attributes (e.g. accessibility class, biometry requirements),
+  Associated Domains validation, ASAuthorization callback handling.
+- Common OWASP-class issues: injection, unsafe deserialization, insecure defaults,
+  overly-broad exception handling that swallows security-relevant failures.
+
+Do not raise generic style, performance, or test-coverage findings — leave those to other
+specialists. If nothing in the diff is security-relevant, return `[]`.

--- a/scripts/pr-review/prompts/tests.md
+++ b/scripts/pr-review/prompts/tests.md
@@ -1,0 +1,16 @@
+## Role: test-coverage reviewer
+
+You are the test-coverage specialist in a fan-out PR review. Focus only on testing gaps in
+the diff:
+
+- New branches (error paths, null/empty/malformed input, platform exceptions) added without a
+  corresponding test.
+- Existing tests that were weakened, deleted, or made to assert less than before without
+  justification in the diff.
+- Mismatches between what a test claims to verify (its name/description) and what it actually
+  asserts.
+- For native code changes (Kotlin/Swift), missing coverage for the new code path in the
+  package's existing unit test suite, where one exists.
+
+Do not raise correctness, security, or style findings — leave those to other specialists. If
+the diff has adequate coverage for its risk level, or touches no testable logic, return `[]`.

--- a/scripts/pr-review/prompts/web.md
+++ b/scripts/pr-review/prompts/web.md
@@ -1,0 +1,62 @@
+## Role: web reviewer
+
+You are the web specialist in a fan-out PR review, covering `packages/credential_manager_web`
+(Dart JS-interop glue in `lib/`, and the TypeScript/JS source in `lib/javascript/` and its
+compiled output in `web/passkey_authenticator.js` / `web/index.d.ts`). Focus on:
+
+- WebAuthn/Credential Management API correctness: `navigator.credentials.create`/`.get` option
+  shaping, base64url encoding/decoding of challenge/id fields, `PublicKeyCredential` response
+  parsing.
+- Google Identity Services / FedCM: script load ordering relative to Flutter bootstrap (a race
+  here silently breaks "one tap" on first load), OAuth client type (Web application client vs.
+  other platform types) mismatches, `credential_manager_web_plugin.dart` <-> JS interop signature
+  drift (a renamed/reordered JS export not mirrored in `passkey_authenticator_interop.dart`, or
+  vice versa).
+- Generated/compiled artifacts: `web/passkey_authenticator.js` and `web/index.d.ts` are build
+  output of `lib/javascript/` (via `rollup.config.js`) — flag a PR that hand-edits the compiled
+  `.js`/`.d.ts` without a corresponding source change (or vice versa), since that's a
+  single-source-of-truth violation for this package specifically.
+- Browser-specific failure modes: feature-detection gaps (calling a WebAuthn/FedCM API without
+  checking `PublicKeyCredential`/`IdentityCredential` support), unhandled `DOMException` types
+  from `navigator.credentials`, promise rejections not surfaced back across the JS-interop
+  boundary to the Dart `Future`.
+- The `web/index.html` `<script>` contract: the JS bundle must load via
+  `assets/packages/credential_manager_web/web/passkey_authenticator.js` (note the `assets/`
+  prefix — `flutter build web` nests plugin web assets under `build/web/assets/packages/...`,
+  there is no top-level `packages/` dir in a static build) and **before**
+  `flutter_bootstrap.js`/Flutter boot. A change to this path, or that reorders it after Flutter
+  boot, silently breaks every consumer at `init()` with `CredentialException(code: 101, ...)` —
+  treat any edit to this script tag or its documented path as high severity, and flag it even if
+  it "still works" in `flutter run -d chrome` (the dev server resolves unprefixed `packages/...`
+  too, masking exactly this class of bug until a real static deploy).
+- `credential_manager_web` is loaded through a conditional import gated on
+  `dart.library.js_interop` (`web_registration_stub.dart` if / `web_registration_web.dart` when
+  the library is available) from `credential_manager_core.dart` — never a bare
+  `import 'package:credential_manager_web/...'` anywhere reachable from a non-web build target;
+  that breaks Android/iOS compilation outright (`'JSString' isn't a type`). Flag any diff that
+  adds a new Web-only Dart dependency to shared/umbrella code without following this same
+  conditional-import pattern.
+- Google Identity Services (GIS, `accounts.google.com/gsi/client`) backed by FedCM is the
+  supported Google Sign-In integration on Web — flag any reintroduction of a raw
+  `navigator.credentials.get({identity: {providers: [...]}})` FedCM call as the primary
+  implementation; this repo already tried that and hit unrecoverable backend errors from
+  third-party RPs. GIS requires the calling origin to be pre-registered under "Authorized
+  JavaScript origins" on the same **Web application** OAuth client used for Android — a
+  same-origin/config mismatch here fails with an opaque `400`, no trailing-slash tolerance.
+- `saveGoogleCredential(useButtonFlow: true)` on Web renders GIS's real button off-screen and
+  forwards the click to preserve transient user activation — it must be invoked synchronously
+  from a genuine click handler, not after an intervening `await`. Flag a diff that adds an
+  `await` (or any async gap) between the user gesture and this call.
+- Retrieval asymmetry: `getCredentials` on Web is documented as **not** supporting password
+  credentials even when `FetchOptionsAndroid(passwordCredential: true)` is set (it tries passkey,
+  then falls back to Google Sign-In only) — a change that appears to add Web password retrieval
+  through this entry point without actually wiring a new code path is likely a silent no-op;
+  verify it isn't just inheriting Android's option flag with no Web-side effect.
+- `web/passkey_authenticator.js` / `web/index.d.ts` are compiled output of
+  `lib/javascript/src/*.ts` via `npm run build` (rollup) — they are not rebuilt automatically by
+  `flutter build`/`flutter run`. A diff touching `lib/javascript/src/**` must also update the
+  compiled `web/*.js`/`.d.ts` in the same PR (or vice versa); treat a source-only or
+  output-only change here as an unfinished build step, not intentional drift.
+
+Do not raise Android, iOS, or generic test-coverage findings — leave those to other specialists.
+If the diff has no web-specific issues, return `[]`.

--- a/scripts/pr-review/review.sh
+++ b/scripts/pr-review/review.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Local PR reviewer.
+#
+# Fans out specialist Claude Code review passes over a GitHub PR's diff (security,
+# test-coverage, and whichever of android/ios/dart apply to the changed files), synthesizes
+# the results with a primary reviewer pass, and posts the surviving findings as inline PR
+# review comments. Modeled on the "LLM as one bounded, structured-output stage in a normal
+# pipeline" pattern from https://www.huuhka.net/building-your-own-pr-reviewer-with-coding-agents/,
+# right-sized to a single local script instead of a hosted event-driven service.
+#
+# Usage:
+#   scripts/pr-review/review.sh <pr-number> [--dry-run]
+#
+# Requires: gh (authenticated), jq, claude (Claude Code CLI, logged in).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROMPTS_DIR="$SCRIPT_DIR/prompts"
+
+usage() {
+  echo "Usage: $0 <pr-number> [--dry-run]" >&2
+  exit 1
+}
+
+[[ $# -ge 1 ]] || usage
+PR="$1"
+DRY_RUN=false
+[[ "${2:-}" == "--dry-run" ]] && DRY_RUN=true
+
+for bin in gh jq claude; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "error: '$bin' is required on PATH" >&2; exit 1; }
+done
+
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+echo "==> Reviewing $REPO#$PR"
+
+PR_JSON="$(gh pr view "$PR" --json headRefOid,files)"
+HEAD_SHA="$(jq -r '.headRefOid' <<<"$PR_JSON")"
+FILES="$(jq -r '.files[].path' <<<"$PR_JSON")"
+
+echo "==> Files changed:"
+sed 's/^/    /' <<<"$FILES"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# --- pick specialists based on touched paths ---
+SPECIALISTS=(security tests hygiene)
+NEEDS_DOCS=false
+grep -q '^packages/credential_manager_android/' <<<"$FILES" && { SPECIALISTS+=(android); NEEDS_DOCS=true; }
+grep -q '^packages/credential_manager_ios/' <<<"$FILES" && { SPECIALISTS+=(ios); NEEDS_DOCS=true; }
+grep -q '^packages/credential_manager_web/' <<<"$FILES" && { SPECIALISTS+=(web); NEEDS_DOCS=true; }
+grep -qE '\.dart$' <<<"$FILES" && { SPECIALISTS+=(dart); NEEDS_DOCS=true; }
+# pubspec.yaml changes alone (e.g. a version bump with no code) don't need the API/setup-docs
+# reviewer — NEEDS_DOCS is only set by an actual source-surface change above.
+$NEEDS_DOCS && SPECIALISTS+=(docs)
+
+echo "==> Specialists: ${SPECIALISTS[*]}"
+
+# Read-only tool set: specialists inspect the diff/repo but never edit anything.
+CLAUDE_FLAGS=(
+  --permission-mode bypassPermissions
+  --allowedTools "Read Grep Glob Bash(gh pr diff*) Bash(gh pr view*) Bash(git log*) Bash(git show*)"
+  --output-format json
+  -p
+)
+
+render_prompt() {
+  local file="$1"
+  local text
+  text="$(cat "$PROMPTS_DIR/_schema.md" "$file")"
+  text="${text//\{\{PR_NUMBER\}\}/$PR}"
+  printf '%s' "$text"
+}
+
+run_specialist() {
+  local name="$1"
+  local out_file="$WORKDIR/${name}.json"
+  echo "    -> running $name reviewer..."
+  local prompt
+  prompt="$(render_prompt "$PROMPTS_DIR/${name}.md")"
+  if ! claude "${CLAUDE_FLAGS[@]}" "$prompt" | jq -r '.result' >"$out_file" 2>"$WORKDIR/${name}.log"; then
+    echo "    !! $name reviewer failed, treating as no findings (see $WORKDIR/${name}.log)" >&2
+    echo "[]" >"$out_file"
+  fi
+  jq -e . "$out_file" >/dev/null 2>&1 || echo "[]" >"$out_file"
+}
+
+pids=()
+for s in "${SPECIALISTS[@]}"; do
+  run_specialist "$s" &
+  pids+=($!)
+done
+for pid in "${pids[@]}"; do
+  wait "$pid"
+done
+
+echo "==> Specialist findings:"
+for s in "${SPECIALISTS[@]}"; do
+  n="$(jq 'length' "$WORKDIR/${s}.json")"
+  echo "    $s: $n"
+done
+
+RAW_FINDINGS="$(jq -s 'add' "$WORKDIR"/*.json)"
+
+if [[ "$(jq 'length' <<<"$RAW_FINDINGS")" -eq 0 ]]; then
+  echo "==> No specialist findings. Nothing to synthesize or post."
+  exit 0
+fi
+
+# --- synthesize ---
+echo "==> Synthesizing findings with primary reviewer..."
+SYNTH_PROMPT="$(render_prompt "$PROMPTS_DIR/primary.md")"
+SYNTH_PROMPT="${SYNTH_PROMPT//\{\{FINDINGS_JSON\}\}/$RAW_FINDINGS}"
+
+FINAL_JSON="$(claude "${CLAUDE_FLAGS[@]}" "$SYNTH_PROMPT" | jq -r '.result')"
+jq -e . <<<"$FINAL_JSON" >/dev/null 2>&1 || FINAL_JSON="[]"
+echo "$FINAL_JSON" >"$WORKDIR/final.json"
+
+COUNT="$(jq 'length' <<<"$FINAL_JSON")"
+echo "==> $COUNT finding(s) after synthesis"
+[[ "$COUNT" -eq 0 ]] && { echo "Nothing to post."; exit 0; }
+
+# --- post inline review comments ---
+jq -c 'map(. as $f | . + {_rank: (["critical","high","medium","low"] | index($f.severity))})
+       | sort_by(._rank) | .[] | del(._rank)' <<<"$FINAL_JSON" |
+while IFS= read -r finding; do
+  title="$(jq -r '.title' <<<"$finding")"
+  severity="$(jq -r '.severity' <<<"$finding")"
+  category="$(jq -r '.category // "general"' <<<"$finding")"
+  file="$(jq -r '.file' <<<"$finding")"
+  line="$(jq -r '.line' <<<"$finding")"
+  desc="$(jq -r '.description' <<<"$finding")"
+
+  echo "----"
+  echo "[$severity] $file:$line — $title"
+
+  $DRY_RUN && continue
+
+  body="**[$severity] $title** _(${category})_
+
+${desc}"
+
+  if ! gh api "repos/$REPO/pulls/$PR/comments" \
+    -f commit_id="$HEAD_SHA" \
+    -f path="$file" \
+    -F line="$line" \
+    -f side="RIGHT" \
+    -f body="$body" >/dev/null; then
+    echo "    (failed to post inline comment — line may be outside the diff hunk; falling back to a general PR comment)"
+    gh pr comment "$PR" --body "**[$severity] ${file}:${line} — ${title}** _(${category})_
+
+${desc}" >/dev/null
+  fi
+done
+
+echo "==> Done."


### PR DESCRIPTION
## Summary
- Adds `scripts/pr-review/review.sh`, a local multi-agent PR reviewer: fans out specialist Claude Code review passes (security, tests, hygiene, docs-sync, and android/ios/web/dart as applicable to the touched files) over a GitHub PR's diff, synthesizes findings with a primary reviewer pass, and posts surviving findings as inline PR comments.
- Specialist prompts are grounded in this repo's actual conventions (`CLAUDE.md` version-bump/CHANGELOG rules, single-source-of-truth requirements) and the plugin's real API surface / native setup requirements (from the `credential-manager-expert` skill references), rather than generic best-practice guessing — informed by reviewing this repo's full PR comment history (human + CodeRabbit) to find real recurring gaps (e.g. no `credential_manager_web` coverage existed at all before this change).
- Wired up via `make pr-review PR=<number> [DRY_RUN=1]`.
- `.gitignore`: ignore `build/` (melos/pub build artifacts).

## Test plan
- [x] `bash -n scripts/pr-review/review.sh` (syntax check)
- [x] Ran `scripts/pr-review/review.sh 96 --dry-run` and `101 --dry-run` against real merged PRs — specialist selection, prompt rendering, and synthesis all completed without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)