### PR TITLE
docs: document remaining public API in credential_manager (100% API coverage)

### DIFF
--- a/packages/credential_manager/lib/credential_manager.dart
+++ b/packages/credential_manager/lib/credential_manager.dart
@@ -1,3 +1,8 @@
+/// A unified Flutter API for platform credential storage: one-tap sign-in and
+/// passkeys via Android's Jetpack Credential Manager, and Keychain/Autofill on
+/// iOS, behind a single [CredentialManager] entry point.
+library;
+
 // Export platform interface and models from platform_interface
 export 'package:credential_manager_platform_interface/credential_manager_platform_interface.dart';
 

--- a/packages/credential_manager/lib/src/utils/encryption.dart
+++ b/packages/credential_manager/lib/src/utils/encryption.dart
@@ -2,8 +2,12 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
-/// A utility class for encrypting and decrypting data using the AES algorithm.
+/// Generates cryptographically-random, Base64URL-encoded identifiers for passkey requests.
 class EncryptData {
+  /// This class only exposes static members and is not meant to be instantiated.
+  EncryptData._();
+
+  /// Generates a random 64-byte user ID, Base64URL-encoded with padding stripped.
   static String getEncodedUserId() {
     final random = Random.secure();
     final bytes = Uint8List(64);
@@ -13,6 +17,7 @@ class EncryptData {
     return base64UrlEncode(bytes).replaceAll('=', '');
   }
 
+  /// Generates a random 32-byte challenge, Base64URL-encoded with padding stripped.
   static String getEncodedChallenge() {
     final random = Random.secure();
     final bytes = Uint8List(32);

--- a/packages/credential_manager/lib/src/utils/platform.dart
+++ b/packages/credential_manager/lib/src/utils/platform.dart
@@ -1,14 +1,25 @@
 import 'package:flutter/foundation.dart';
 
+/// Detects which platform the app is currently running on.
+///
+/// A single instance is computed once (via [instance]) and reused, since
+/// [defaultTargetPlatform] doesn't change during the lifetime of an app.
 class CredentialManagerPlatformManager {
+  /// Whether the app is currently running on Android.
   late final bool isAndroid;
+
+  /// Whether the app is currently running on iOS.
   late final bool isIOS;
+
+  /// Whether the app is currently running on the web.
   late final bool isWeb;
 
   static final CredentialManagerPlatformManager _instance = CredentialManagerPlatformManager._internal();
 
+  /// Returns the shared [CredentialManagerPlatformManager] instance.
   factory CredentialManagerPlatformManager() => _instance;
 
+  /// The shared [CredentialManagerPlatformManager] instance.
   static CredentialManagerPlatformManager get instance => _instance;
 
   CredentialManagerPlatformManager._internal() {


### PR DESCRIPTION
## Summary
- Closes the public-API documentation gap the pub.dev score page flagged for `credential_manager` (was 78.8% documented — well above the 20% threshold for full points, but not complete).
- Adds a library-level doc comment to `credential_manager.dart`.
- Documents `CredentialManagerPlatformManager` (exported via `src/utils/platform.dart`) — class, constructor/`instance`, and the three platform-detection fields.
- Documents `EncryptData`'s two static methods, gives it a private constructor (it's a static-only utility, never externally instantiated — grepped for `EncryptData(` usage, found none) so its own doc comment attaches to something dartdoc reports on, and corrects its class doc, which claimed AES encryption/decryption it doesn't actually do (it only generates random Base64URL-encoded IDs/challenges).

Verified locally with `pana .`: **100% of public API now documented**, still 160/160 pub points, `make check` clean.

Note: this only takes effect on the live pub.dev score page once `credential_manager` is republished — this PR just lands the source change. No version bump included; let me know if you want this rolled into a small release.

## Test plan
- [x] `make check` (format-check + analyze + SwiftLint + Detekt) — clean
- [x] `pana .` on `packages/credential_manager` — 100% API documented, 160/160 points
- [ ] Human review + merge into `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)