### PR TITLE
fix(android): align Kotlin JVM target with Java 17

### DIFF
--- a/packages/credential_manager_android/CHANGELOG.md
+++ b/packages/credential_manager_android/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Explicitly target JVM 17 for Kotlin to match Java compilation after the built-in Kotlin migration, including when Flutter applies KGP with built-in Kotlin disabled on JDK 21.
+
 # 4.0.0
 - Bumped `credential_manager_platform_interface` to `^4.0.0` (required for `prepareCredentials` and
   `allowCredentials`)

--- a/packages/credential_manager_android/android/build.gradle
+++ b/packages/credential_manager_android/android/build.gradle
@@ -73,6 +73,12 @@ android {
     }
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}
+
 dependencies {
     detektPlugins 'io.gitlab.arturbosch.detekt:detekt-formatting:1.23.7'
     implementation 'androidx.annotation:annotation:1.9.1'


### PR DESCRIPTION
Fix Android compilation for consuming Flutter apps that disable built-in Kotlin and run Gradle on JDK 21. Previously, Java targeted JVM 17 while Kotlin targeted JVM 21, causing `:credential_manager_android:compileDebugKotlin` to fail.

Set `kotlin.compilerOptions.jvmTarget` to `JvmTarget.JVM_17`, matching the existing Java compile options and the [Flutter plugin migration guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors).

The change restores the explicit Kotlin target removed during the migration in #94 without reintroducing an explicit KGP application. It also adds an Android package changelog entry. No runtime code or public API changes are included.

Fixes #110

Related: #103 covers the earlier error from explicitly applying KGP with built-in Kotlin enabled. This PR addresses the separate JVM target mismatch.

## Validation

- Reproduced the JVM 17/21 mismatch with published `credential_manager_android` 4.0.0.
- Verified the patch in a consuming app using Flutter 3.47.1, Dart 3.13.1, AGP 9.0.1, Gradle 9.1.0, KGP 2.3.20, and JDK 21.0.9.
- The application uses `android.builtInKotlin=false` and `android.newDsl=false`.
- The complete debug build passed, including the previously failing Kotlin task:

```sh
./gradlew :app:assembleDebug --no-daemon \
  -Pkotlin.compiler.execution.strategy=in-process
```

Built-in Kotlin enabled, the upstream example build, and the repository-wide `make check` / `flutter test` checks were not run for this patch.

Co-authored by GPT-6
