### PR TITLE
chore: release v5.1.0 (credential_manager) / v4.1.0 (credential_manager_android)

### DIFF
--- a/packages/credential_manager/CHANGELOG.md
+++ b/packages/credential_manager/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-# 5.0.0
+# 5.1.0
+- Bumped `credential_manager_android` to `^4.1.0`, fixing `compileDebugKotlin` failures for consuming apps that
+  disable built-in Kotlin and run Gradle on JDK 21+ — see its own CHANGELOG for details
+- Documented the remainder of this package's public API (`CredentialManagerPlatformManager`, `EncryptData`, and
+  a library-level doc comment), bringing public API documentation coverage to 100%
+- No breaking changes to this package's own public Dart API
+
+## 5.0.0
 - Bumped `credential_manager_platform_interface` to `^4.0.0`, `credential_manager_android` to `^4.0.0`,
   `credential_manager_ios` to `^4.0.0`, and `credential_manager_web` to `^2.3.0`
 - Added `prepareCredentials`, which prefetches a matching Android credential request on Android 14 and newer and

--- a/packages/credential_manager/pubspec.yaml
+++ b/packages/credential_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Credential Manager plugin. Provides one-tap login functionality and stores credentials
   in the user's Google account on Android and in the Keychain on iOS.
 
-version: 5.0.0
+version: 5.1.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   credential_manager_platform_interface: ^4.0.0
-  credential_manager_android: ^4.0.0
+  credential_manager_android: ^4.1.0
   credential_manager_ios: ^4.0.0
   credential_manager_web: ^2.3.0
 

--- a/packages/credential_manager_android/CHANGELOG.md
+++ b/packages/credential_manager_android/CHANGELOG.md
@@ -1,7 +1,10 @@
-## Unreleased
-- Explicitly target JVM 17 for Kotlin to match Java compilation after the built-in Kotlin migration, including when Flutter applies KGP with built-in Kotlin disabled on JDK 21.
+# 4.1.0
+- Explicitly target JVM 17 for Kotlin to match Java compilation after the built-in Kotlin migration, fixing
+  `compileDebugKotlin` failures for consuming apps that disable built-in Kotlin and run Gradle on JDK 21 or
+  newer (Kotlin previously defaulted to targeting whichever JVM ran Gradle, instead of matching Java's JVM 17).
+- No breaking changes to the public Dart API.
 
-# 4.0.0
+## 4.0.0
 - Bumped `credential_manager_platform_interface` to `^4.0.0` (required for `prepareCredentials` and
   `allowCredentials`)
 - `getCredentials` now applies the `preferImmediatelyAvailableCredentials` value supplied during initialization.

--- a/packages/credential_manager_android/pubspec.yaml
+++ b/packages/credential_manager_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: credential_manager_android
 description: Android implementation of the credential_manager plugin using Jetpack Credential Manager API.
-version: 4.0.0
+version: 4.1.0
 homepage: https://djsmk123.github.io/flutter_credential_manager_compose
 repository: https://github.com/Djsmk123/flutter_credential_manager_compose
 environment:


### PR DESCRIPTION
## Summary
Promotes `develop` to `main` to prepare pub.dev publishing. Covers everything merged since `v.5.0.0`:

- fix(android): align Kotlin JVM target with Java 17, fixing `compileDebugKotlin` failures for consuming apps that disable built-in Kotlin and run Gradle on JDK 21+ (#111)
- docs: document the remainder of `credential_manager`'s public API, bringing coverage to 100% (#109)

Version bumps (bug fix / small change → minor, per this repo's convention):
- `credential_manager_android`: 4.0.0 → **4.1.0**
- `credential_manager` (umbrella): 5.0.0 → **5.1.0** (dependency bump to `credential_manager_android: ^4.1.0` + doc-coverage note)
- `credential_manager_platform_interface`, `credential_manager_ios`, `credential_manager_web`: untouched, no bump

## Test plan
- [x] `make check` (format-check + analyze + SwiftLint + Detekt) — clean
- [x] PR #111's fix independently reproduced and verified locally (JDK 21, AGP 9.0.1, Gradle 9.1.0, `android.builtInKotlin=false`): build failed before the patch with the exact reported error, succeeded after
- [ ] Human review + merge into `main`
- [ ] `flutter pub publish --dry-run` for `credential_manager_android` then `credential_manager`, then real publish with explicit go-ahead per package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Kotlin compilation failures in consuming Android apps that use newer JDK versions and disable built-in Kotlin support.
  * Android builds now consistently target JVM 17.

* **Release Updates**
  * Released Credential Manager 5.1.0 and Credential Manager Android 4.1.0.
  * Confirmed no breaking changes to the public Dart API.
  * Expanded API documentation coverage details in the release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->